### PR TITLE
Make the StubStore more asynchronous.

### DIFF
--- a/async/stub/com/treode/async/stubs/AsyncChecks.scala
+++ b/async/stub/com/treode/async/stubs/AsyncChecks.scala
@@ -21,30 +21,24 @@ import scala.util.Random
 
 import com.treode.async.Scheduler
 import org.scalatest.{Informing, Suite}
-import org.scalatest.concurrent.TimeLimitedTests
-import org.scalatest.time.SpanSugar
 
-import SpanSugar._
-
-trait AsyncChecks extends TimeLimitedTests {
+trait AsyncChecks {
   this: Suite with Informing =>
 
-  val timeLimit = 5 minutes
-
-  /** The value of `TEST_INTENSITY` from the environment, or `standard` if the environment has
-    * no setting for that.
+  /** The value of `TEST_INTENSITY` from the environment, or `std` if the environment has no
+    * setting for that.
     */
   val intensity: String = {
     val env = System.getenv ("TEST_INTENSITY")
-    if (env == null) "standard" else env
+    if (env == null) "std" else env
   }
 
-  /** The number of seeds tried in `forAllSeeds`.  1 when when `intensity` is `development` and
-    * 100 otherwise.
+  /** The number of seeds tried in `forAllSeeds`.  1 when when `intensity` is `dev` and 100
+    * otherwise.
     */
   val nseeds =
     intensity match {
-      case "development" => 1
+      case "dev" => 1
       case _ => 100
     }
 
@@ -60,23 +54,10 @@ trait AsyncChecks extends TimeLimitedTests {
     }}
 
   /** Run the test many times, each time with a PRNG seeded differently.  When developing, set
-    * the environment variable `TEST_INTENSITY` to `development` to run the test only once.  Let
-    * your continuous build spend the time running it over and over.
+    * the environment variable `TEST_INTENSITY` to `dev` to run the test only once.  Let your
+    * continuous build spend the time running it over and over.
     */
   def forAllSeeds (test: Random => Any) {
     for (_ <- 0 until nseeds)
       forSeed (Random.nextLong) (test)
-  }
-
-  /** Run the test with a multithreaded scheduler, and then shutdown the underlying executor after
-    * the test completes.
-    */
-  def multithreaded (test: StubScheduler => Any) {
-    val processors = Runtime.getRuntime.availableProcessors
-    val threads = if (processors < 8) 4 else 8
-    val executor = Executors.newScheduledThreadPool (threads)
-    try {
-      test (StubScheduler.multithreaded (executor))
-    } finally {
-      executor.shutdown()
-    }}}
+  }}

--- a/async/stub/com/treode/async/stubs/StubScheduler.scala
+++ b/async/stub/com/treode/async/stubs/StubScheduler.scala
@@ -16,7 +16,7 @@
 
 package com.treode.async.stubs
 
-import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.{Executors, ScheduledExecutorService}
 import scala.util.Random
 
 import com.treode.async.Scheduler
@@ -28,12 +28,54 @@ trait StubScheduler extends Scheduler {
 
 object StubScheduler {
 
+  /** Run the tasks and timers one at a time in the thread that invokes the `run` method. Runs all
+    * outstanding tasks, choosing the next task at random. If the timers parameter yields `true`,
+    * then runs all outstanding timers too. Keeps going while there are outstanding tasks or timers
+    * and `timers` yields `true`, or while there are outstanding `tasks` and `timers` yields false.
+    *
+    * This always uses a PRNG seeded with 0.
+    */
   def random(): StubScheduler =
     new RandomScheduler (new Random (0))
 
+  /** Run the tasks and timers one at a time in the thread that invokes the `run` method. Runs all
+    * outstanding tasks, choosing the next task at random. If the timers parameter yields `true`,
+    * then runs all outstanding timers too. Keeps going while there are outstanding tasks or timers
+    * and `timers` yields `true`, or while there are outstanding `tasks` and `timers` yields false.
+    *
+    * You can run a test many times, each time providing a PRNG seeded from a different value, and
+    * thereby choose different interleavings of tasks. This cannot detect all multithreading bugs,
+    * but it can detect some, and it will surely boost your confidence that your code works.
+    */
   def random (random: Random): StubScheduler =
     new RandomScheduler (random)
 
-  def multithreaded (executor: ScheduledExecutorService): StubScheduler =
+  /** Wrap the given executor. This scheduler runs the tasks in one or more threads separate from
+    * from the thread that calls `run`. The `run` method periodically checks the result of the
+    * `timers` parameter, and it loops while that method returns `true`. This scheduler runs per
+    * the executor's timer regarless of the `timers` parameter.
+    */
+  def wrapped (executor: ScheduledExecutorService): StubScheduler =
     new StubExecutorAdaptor (executor)
-}
+
+  /** Loan a scheduler that wraps Java's single threaded executor, and shutdown the underlying
+    * executor after the test completes.
+    */
+  def singlethreaded (test: StubScheduler => Any) {
+    val executor = Executors.newSingleThreadScheduledExecutor
+    try
+      test (wrapped (executor))
+    finally
+      executor.shutdown()
+  }
+
+  /** Loan a scheduler that wraps Java's pooled threads executor, and shutdown the underlying
+    * executor after the test completes.
+    */
+  def multithreaded (test: StubScheduler => Any) {
+    val executor = Executors.newScheduledThreadPool (4)
+    try
+      test (wrapped (executor))
+    finally
+      executor.shutdown()
+  }}

--- a/cluster/test/com/treode/cluster/ClusterLiveSpec.scala
+++ b/cluster/test/com/treode/cluster/ClusterLiveSpec.scala
@@ -29,8 +29,9 @@ import org.scalatest.FlatSpec
 
 import Async.{async, supply}
 import Callback.{ignore => disregard}
+import StubScheduler.multithreaded
 
-class ClusterLiveSpec extends FlatSpec with AsyncChecks {
+class ClusterLiveSpec extends FlatSpec {
 
   implicit val random = Random
   implicit val config = Cluster.Config.suggested

--- a/disk/stub/com/treode/disk/stubs/CrashChecks.scala
+++ b/disk/stub/com/treode/disk/stubs/CrashChecks.scala
@@ -22,13 +22,19 @@ import com.treode.async.Async
 import com.treode.async.stubs.{AsyncChecks, StubScheduler}
 import com.treode.async.stubs.implicits._
 import org.scalatest.{Assertions, Informing, Suite}
+import org.scalatest.concurrent.TimeLimitedTests
+import org.scalatest.time.SpanSugar
 
-trait CrashChecks extends AsyncChecks {
+import SpanSugar._
+
+trait CrashChecks extends AsyncChecks with TimeLimitedTests {
   this: Suite with Informing =>
+
+  override val timeLimit = 5 minutes
 
   private val ncrashes =
     intensity match {
-      case "development" => 1
+      case "dev" => 1
       case _ => 10
     }
 

--- a/disk/test/com/treode/disk/DiskSystemSpec.scala
+++ b/disk/test/com/treode/disk/DiskSystemSpec.scala
@@ -31,6 +31,7 @@ import org.scalatest.time.SpanSugar
 import Async.{latch, supply}
 import DiskTestTools._
 import SpanSugar._
+import StubScheduler.multithreaded
 
 class DiskSystemSpec extends FreeSpec with CrashChecks {
 

--- a/examples/finatra/src/test/scala/example/ResourceSpec.scala
+++ b/examples/finatra/src/test/scala/example/ResourceSpec.scala
@@ -23,6 +23,7 @@ import com.twitter.finagle.http.MediaType
 import com.twitter.finatra.test.{MockApp, MockResult}
 import org.scalatest.{FreeSpec, Matchers}
 
+import StubScheduler.singlethreaded
 import WriteOp._
 
 class ResourceSpec extends FreeSpec with Matchers with SpecTools {
@@ -34,34 +35,33 @@ class ResourceSpec extends FreeSpec with Matchers with SpecTools {
 
   "When the database is empty" - {
 
-    "GET /table/123?key=abc should respond Not Found" in {
-      implicit val scheduler = StubScheduler.random()
-      val store = StubStore()
-      val mock = newMock (store)
-      val response = mock.get ("/table/123?key=abc")
-      response.code should equal (NotFound)
-    }
+    "GET /table/123?key=abc should respond Not Found" in
+      singlethreaded { implicit scheduler =>
+        val store = StubStore()
+        val mock = newMock (store)
+        val response = mock.get ("/table/123?key=abc")
+        response.code should equal (NotFound)
+      }
 
-    "PUT /table/123?key=abc with a condition should respond Ok with an etag" in {
-      implicit val scheduler = StubScheduler.random()
-      val store = StubStore()
-      val mock = newMock (store)
-      val body = "\"i have been stored\""
-      val response = mock.put (
-          "/table/123?key=abc",
-          headers = Map (ContentType -> MediaType.Json),
-          body = body)
-      response.code should equal (Ok)
-      val etag = response.etag
-      store.scan (123) should be (Seq (cell ("abc", etag, body)))
-    }}
+    "PUT /table/123?key=abc with a condition should respond Ok with an etag" in
+      singlethreaded { implicit scheduler =>
+        val store = StubStore()
+        val mock = newMock (store)
+        val body = "\"i have been stored\""
+        val response = mock.put (
+            "/table/123?key=abc",
+            headers = Map (ContentType -> MediaType.Json),
+            body = body)
+        response.code should equal (Ok)
+        val etag = response.etag
+        store.scan (123) should be (Seq (cell ("abc", etag, body)))
+      }}
 
   "When the database has an entry" - {
 
     val entity = "\"you found me\""
 
-    def setup() = {
-      implicit val scheduler = StubScheduler.random()
+    def setup () (implicit scheduler: StubScheduler) = {
       val store = StubStore()
       val mock = newMock (store)
       val ts = store.write (TxId (Bytes (1), 0), TxClock.MinValue,
@@ -69,82 +69,90 @@ class ResourceSpec extends FreeSpec with Matchers with SpecTools {
       (store, mock, ts)
     }
 
-    "GET /table/123?key=abc should respond Ok" in {
-      val (store, mock, ts) = setup()
-      val response = mock.get ("/table/123?key=abc")
-      response.code should equal (Ok)
-      response.etag should be (ts)
-      response.body should be (entity)
-    }
+    "GET /table/123?key=abc should respond Ok" in
+      singlethreaded { implicit scheduler =>
+        val (store, mock, ts) = setup()
+        val response = mock.get ("/table/123?key=abc")
+        response.code should equal (Ok)
+        response.etag should be (ts)
+        response.body should be (entity)
+      }
 
-    "GET /table/123?key=abc with If-Modified-Since:0 should respond Ok" in {
-      val (store, mock, ts) = setup()
-      val response = mock.get (
-          "/table/123?key=abc",
-          headers = Map (IfModifiedSince -> "0"))
-      response.code should equal (Ok)
-      response.etag should be (ts)
-      response.body should be (entity)
-    }
+    "GET /table/123?key=abc with If-Modified-Since:0 should respond Ok" in
+      singlethreaded { implicit scheduler =>
+        val (store, mock, ts) = setup()
+        val response = mock.get (
+            "/table/123?key=abc",
+            headers = Map (IfModifiedSince -> "0"))
+        response.code should equal (Ok)
+        response.etag should be (ts)
+        response.body should be (entity)
+      }
 
-    "GET /table/123?key=abc with If-Modified-Since:1 should respond Not Modified" in {
-      val (store, mock, ts) = setup()
-      val response = mock.get (
-          "/table/123?key=abc",
-          headers = Map (IfModifiedSince -> "1"))
-      response.code should equal (NotModified)
-      response.body should be ("")
-    }
+    "GET /table/123?key=abc with If-Modified-Since:1 should respond Not Modified" in
+      singlethreaded { implicit scheduler =>
+        val (store, mock, ts) = setup()
+        val response = mock.get (
+            "/table/123?key=abc",
+            headers = Map (IfModifiedSince -> "1"))
+        response.code should equal (NotModified)
+        response.body should be ("")
+      }
 
-    "GET /table/123?key=abc with Last-Modification-Before:0 should respond Not Found" in {
-      val (store, mock, ts) = setup()
-      val response = mock.get (
-          "/table/123?key=abc",
-          headers = Map (LastModificationBefore -> (ts-1).toString))
-      response.code should equal (NotFound)
-    }
+    "GET /table/123?key=abc with Last-Modification-Before:0 should respond Not Found" in
+      singlethreaded { implicit scheduler =>
+        val (store, mock, ts) = setup()
+        val response = mock.get (
+            "/table/123?key=abc",
+            headers = Map (LastModificationBefore -> (ts-1).toString))
+        response.code should equal (NotFound)
+      }
 
-    "GET /table/123?key=abc with Last-Modification-Before:1 should respond Ok" in {
-      val (store, mock, ts) = setup()
-      val response = mock.get (
-          "/table/123?key=abc",
-          headers = Map (LastModificationBefore -> "1"))
-      response.code should equal (Ok)
-      response.etag should be (ts)
-      response.body should be (entity)
-    }
+    "GET /table/123?key=abc with Last-Modification-Before:1 should respond Ok" in
+      singlethreaded { implicit scheduler =>
+        val (store, mock, ts) = setup()
+        val response = mock.get (
+            "/table/123?key=abc",
+            headers = Map (LastModificationBefore -> "1"))
+        response.code should equal (Ok)
+        response.etag should be (ts)
+        response.body should be (entity)
+      }
 
-    "PUT /table/123?key=abc with should respond Ok with an etag" in {
-      val (store, mock, ts) = setup()
-      val body2 = "\"i have been stored\""
-      val response = mock.put (
-          "/table/123?key=abc",
-          headers = Map (ContentType -> MediaType.Json),
-          body = body2)
-      response.code should equal (Ok)
-      val etag = response.etag
-      store.scan (123) should be (Seq (cell ("abc", etag, body2), cell ("abc", ts, entity)))
-    }
+    "PUT /table/123?key=abc with should respond Ok with an etag" in
+      singlethreaded { implicit scheduler =>
+        val (store, mock, ts) = setup()
+        val body2 = "\"i have been stored\""
+        val response = mock.put (
+            "/table/123?key=abc",
+            headers = Map (ContentType -> MediaType.Json),
+            body = body2)
+        response.code should equal (Ok)
+        val etag = response.etag
+        store.scan (123) should be (Seq (cell ("abc", etag, body2), cell ("abc", ts, entity)))
+      }
 
-    "PUT /table/123?key=abc with a If-Unmodified-Since:1 should respond Ok with an etag" in {
-      val (store, mock, ts) = setup()
-      val body2 = "\"i have been stored\""
-      val response = mock.put (
-          "/table/123?key=abc",
-          headers = Map (ContentType -> MediaType.Json, IfUnmodifiedSince -> "1"),
-          body = body2)
-      response.code should equal (Ok)
-      val etag = response.etag
-      store.scan (123) should be (Seq (cell ("abc", etag, body2), cell ("abc", ts, entity)))
-    }
+    "PUT /table/123?key=abc with a If-Unmodified-Since:1 should respond Ok with an etag" in
+      singlethreaded { implicit scheduler =>
+        val (store, mock, ts) = setup()
+        val body2 = "\"i have been stored\""
+        val response = mock.put (
+            "/table/123?key=abc",
+            headers = Map (ContentType -> MediaType.Json, IfUnmodifiedSince -> "1"),
+            body = body2)
+        response.code should equal (Ok)
+        val etag = response.etag
+        store.scan (123) should be (Seq (cell ("abc", etag, body2), cell ("abc", ts, entity)))
+      }
 
-    "PUT /table/123?key=abc with a If-Unmodified-Since:0 should respond Precondition Failed" in {
-      val (store, mock, ts) = setup()
-      val body2 = "\"i have been stored\""
-      val response = mock.put (
-          "/table/123?key=abc",
-          headers = Map (ContentType -> MediaType.Json, IfUnmodifiedSince -> "0"),
-          body = body2)
-      response.code should equal (PreconditionFailed)
-      store.scan (123) should be (Seq (cell ("abc", ts, entity)))
-    }}}
+    "PUT /table/123?key=abc with a If-Unmodified-Since:0 should respond Precondition Failed" in
+      singlethreaded { implicit scheduler =>
+        val (store, mock, ts) = setup()
+        val body2 = "\"i have been stored\""
+        val response = mock.put (
+            "/table/123?key=abc",
+            headers = Map (ContentType -> MediaType.Json, IfUnmodifiedSince -> "0"),
+            body = body2)
+        response.code should equal (PreconditionFailed)
+        store.scan (123) should be (Seq (cell ("abc", ts, entity)))
+      }}}

--- a/store/test/com/treode/store/StoreClusterChecks.scala
+++ b/store/test/com/treode/store/StoreClusterChecks.scala
@@ -27,6 +27,7 @@ import com.treode.cluster.stubs.{StubHost, StubNetwork}
 import com.treode.disk.stubs.StubDiskDrive
 import com.treode.tags.{Intensive, Periodic}
 import org.scalatest.FreeSpec
+import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.SpanSugar
 
 import Async.{async, supply}
@@ -35,12 +36,12 @@ import SpanSugar._
 import StoreClusterChecks.{Host, Package}
 import StoreTestTools._
 
-trait StoreClusterChecks extends AsyncChecks {
+trait StoreClusterChecks extends AsyncChecks with TimeLimitedTests {
   this: FreeSpec =>
 
   private val ntargets =
     intensity match {
-      case "development" => 1
+      case "dev" => 1
       case _ => 10
     }
 
@@ -330,7 +331,7 @@ trait StoreClusterChecks extends AsyncChecks {
       val executor = Executors.newScheduledThreadPool (nthreads)
       val runner = init (random)
       try {
-        implicit val scheduler = StubScheduler.multithreaded (executor)
+        implicit val scheduler = StubScheduler.wrapped (executor)
         implicit val network = StubNetwork (random)
         test (new StubSchedulerKit (runner))
       } catch {

--- a/store/test/com/treode/store/atomic/AtomicSpec.scala
+++ b/store/test/com/treode/store/atomic/AtomicSpec.scala
@@ -30,8 +30,9 @@ import org.scalatest.time.SpanSugar
 
 import AtomicTestTools._
 import SpanSugar._
+import StubScheduler.multithreaded
 
-class AtomicSpec extends FreeSpec with StoreBehaviors with AsyncChecks {
+class AtomicSpec extends FreeSpec with StoreBehaviors with AsyncChecks with TimeLimitedTests {
 
   override val timeLimit = 15 minutes
 

--- a/store/test/com/treode/store/stubs/StubStoreSpec.scala
+++ b/store/test/com/treode/store/stubs/StubStoreSpec.scala
@@ -25,6 +25,8 @@ import com.treode.tags.{Intensive, Periodic}
 import com.treode.store._
 import org.scalatest.FreeSpec
 
+import StubScheduler.multithreaded
+
 class StubStoreSpec extends FreeSpec with AsyncChecks with StoreBehaviors {
 
   "The StubStore should" - {


### PR DESCRIPTION
Before this change, the read and write functions behaved synchronously, which permitted bugs that could otherwise have been caught. With this change, those methods now queue their responses on the scheduler. This change also cleans up some links between the various *Stub and *Checks classes.
