### PR TITLE
Tracker must allow that no proposal was accepted.

### DIFF
--- a/store/test/com/treode/store/paxos/PaxosTracker.scala
+++ b/store/test/com/treode/store/paxos/PaxosTracker.scala
@@ -102,7 +102,7 @@ class PaxosTracker {
           s"Expected ${key.long} to be $value, found $found.")
     }
     for ((key, found) <- all; if !(accepted contains key)) {
-      val values = attempted (key)
+      val values = attempted (key) + -1
       assert (
           values contains found,
           s"Expected $key to be one of $values, found $found")


### PR DESCRIPTION
This is an error in the test, not the production code. It was being triggered occasionally by the pseudorandom tests.
