### PR TITLE
Use an executor per suite rather than per test.

### DIFF
--- a/async/stub/com/treode/async/stubs/ProvidedSingleThreadScheduler.scala
+++ b/async/stub/com/treode/async/stubs/ProvidedSingleThreadScheduler.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014 Treode, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.treode.async.stubs
+
+import java.util.concurrent.Executors
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+/** Creates a StubScheduler that wraps a single threaded executor before tests runs, and shuts
+  * down the executor after tests runs.  Compare to [[StubScheduler.singlethreaded]] which
+  * creates an executor per test. Executors are heavy weight; creating too many during testing
+  * can consume resources and cause grief.
+  */
+trait ProvidedSingleThreadScheduler extends BeforeAndAfterAll {
+  this: Suite =>
+
+  private val executor = Executors.newSingleThreadScheduledExecutor
+  implicit val scheduler = StubScheduler.wrapped (executor)
+
+  override def afterAll() {
+    executor.shutdown()
+    super.afterAll()
+  }}

--- a/examples/movies/server/test/movies/ActorResourceSpec.scala
+++ b/examples/movies/server/test/movies/ActorResourceSpec.scala
@@ -18,14 +18,12 @@ package movies
 
 import scala.util.Random
 
-import com.treode.async.stubs.StubScheduler
 import com.treode.store.stubs.StubStore
 import com.twitter.finagle.http.MediaType
 import com.twitter.finatra.test.MockApp
 import org.scalatest.{FreeSpec, Matchers}
 
 import movies.{PhysicalModel => PM}
-import StubScheduler.singlethreaded
 
 class ActorResourceSpec extends FreeSpec with Matchers with ResourceSpecTools {
 
@@ -33,7 +31,7 @@ class ActorResourceSpec extends FreeSpec with Matchers with ResourceSpecTools {
 
   val markHammer = """{"id": "1", "name": "Mark Hammer", "born": null, "roles": []}"""
 
-  def setup () (implicit scheduler: StubScheduler) = {
+  def setup () = {
     implicit val random = Random
     implicit val store = StubStore()
     val movies = new MovieStore
@@ -53,205 +51,191 @@ class ActorResourceSpec extends FreeSpec with Matchers with ResourceSpecTools {
 
   "When the database is empty" - {
 
-    "GET /actor/1 should respond Not Found" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val response = mock.get ("/actor/1")
-        response.code should be (NotFound)
-      }
+    "GET /actor/1 should respond Not Found" in {
+      val (store, mock) = setup()
+      val response = mock.get ("/actor/1")
+      response.code should be (NotFound)
+    }
 
-    "PUT /actor/1 should respond Ok with an etag" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val r1 = addMarkHamill (mock)
+    "PUT /actor/1 should respond Ok with an etag" in {
+      val (store, mock) = setup()
+      val r1 = addMarkHamill (mock)
 
-        val t1 = r1.etag
-        store.expectCells (PM.MovieTable) ()
-        store.expectCells (PM.CastTable) ()
-        store.expectCells (PM.ActorTable) (
-            ("1", t1, PO.markHamill))
-        store.expectCells (PM.RolesTable) (
-            ("1", t1, PM.Roles.empty))
-        store.expectCells (PM.Index) (
-            ("mark hamill", t1, PO.actors ("1")))
-      }
+      val t1 = r1.etag
+      store.expectCells (PM.MovieTable) ()
+      store.expectCells (PM.CastTable) ()
+      store.expectCells (PM.ActorTable) (
+          ("1", t1, PO.markHamill))
+      store.expectCells (PM.RolesTable) (
+          ("1", t1, PM.Roles.empty))
+      store.expectCells (PM.Index) (
+          ("mark hamill", t1, PO.actors ("1")))
+    }
 
-    "POST /actor should respond Ok with an etag" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
+    "POST /actor should respond Ok with an etag" in {
+      val (store, mock) = setup()
 
-        val r1 = mock.post (
-            "/actor",
+      val r1 = mock.post (
+          "/actor",
+          headers = Map (ContentType -> MediaType.Json),
+          body = markHamill)
+      r1.code should be (Ok)
+
+      val uri = r1.getHeader (Location)
+      val id = uri.substring ("/actor/".length)
+      val r2 = mock.get (uri)
+      r2.etag should be (r1.etag)
+      r2.body should matchJson (s"""{"id": "$id", "name": "Mark Hamill", "born": null, "roles": []}""")
+    }
+
+    "PUT /actor/1 without a title should respond Bad Requst" in {
+      val (store, mock) = setup()
+      val r1 = mock.put (
+            "/actor/1",
             headers = Map (ContentType -> MediaType.Json),
-            body = markHamill)
-        r1.code should be (Ok)
+            body = "{}")
+      r1.code should be (BadRequest)
 
-        val uri = r1.getHeader (Location)
-        val id = uri.substring ("/actor/".length)
-        val r2 = mock.get (uri)
-        r2.etag should be (r1.etag)
-        r2.body should matchJson (s"""{"id": "$id", "name": "Mark Hamill", "born": null, "roles": []}""")
-      }
+      store.expectCells (PM.MovieTable) ()
+      store.expectCells (PM.CastTable) ()
+      store.expectCells (PM.ActorTable) ()
+      store.expectCells (PM.RolesTable) ()
+      store.expectCells (PM.Index) ()
+    }
 
-    "PUT /actor/1 without a title should respond Bad Requst" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val r1 = mock.put (
-              "/actor/1",
-              headers = Map (ContentType -> MediaType.Json),
-              body = "{}")
-        r1.code should be (BadRequest)
-
-        store.expectCells (PM.MovieTable) ()
-        store.expectCells (PM.CastTable) ()
-        store.expectCells (PM.ActorTable) ()
-        store.expectCells (PM.RolesTable) ()
-        store.expectCells (PM.Index) ()
-      }
-
-    "GET /actor?q=mark should respond Okay" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val response = mock.get ("/actor?q=mark")
-        response.code should equal (Ok)
-        response.body should matchJson (s"""{"movies": [], "actors": []}""")
-      }}
+    "GET /actor?q=mark should respond Okay" in {
+      val (store, mock) = setup()
+      val response = mock.get ("/actor?q=mark")
+      response.code should equal (Ok)
+      response.body should matchJson (s"""{"movies": [], "actors": []}""")
+    }}
 
   "When the database has an actor" - {
 
-    "GET /actor/1 should respond Ok" in
-      singlethreaded { implicit scheduler =>
+    "GET /actor/1 should respond Ok" in {
+      val (store, mock) = setup()
+      val r1 = addMarkHamill (mock)
+      val r2 = mock.get ("/actor/1")
+      r2.code should be (Ok)
+      r2.etag should be (r1.etag)
+      r2.body should matchJson (markHamill)
+    }
+
+    "GET /actor/1 with If-Modified-Since:0 should respond Ok" in {
+      val (store, mock) = setup()
+      val r1 = addMarkHamill (mock)
+      val r2 = mock.get (
+          "/actor/1",
+          headers = Map (IfModifiedSince -> "0"))
+      r2.code should be (Ok)
+      r2.etag should be (r1.etag)
+      r2.body should matchJson (markHamill)
+    }
+
+    "GET /actor/1 with If-Modified-Since:(r1.etag) should respond Not Modified" in {
+      val (store, mock) = setup()
+      val r1 = addMarkHamill (mock)
+      val response = mock.get (
+          "/actor/1",
+          headers = Map (IfModifiedSince -> r1.etag.toString))
+      response.code should be (NotModified)
+      response.body should be ("")
+    }
+
+    "GET /actor/1 with Last-Modification-Before:(r1.etag-1) should respond Not Found" in {
+      val (store, mock) = setup()
+      val r1 = addMarkHamill (mock)
+      val response = mock.get (
+          "/actor/1",
+          headers = Map (LastModificationBefore -> (r1.etag-1).toString))
+      response.code should be (NotFound)
+    }
+
+    "GET /actor/1 with Last-Modification-Before:(r1.etag) should respond Ok" in {
+      val (store, mock) = setup()
+      val r1 = addMarkHamill (mock)
+      val r2 = mock.get (
+          "/actor/1",
+          headers = Map (LastModificationBefore -> r1.etag.toString))
+      r2.code should be (Ok)
+      r2.etag should be (r1.etag)
+      r2.body should matchJson (markHamill)
+    }
+
+    "PUT /actor/1 with should respond Ok with an etag" in {
         val (store, mock) = setup()
-        val r1 = addMarkHamill (mock)
-        val r2 = mock.get ("/actor/1")
-        r2.code should be (Ok)
-        r2.etag should be (r1.etag)
-        r2.body should matchJson (markHamill)
-      }
+      val r1 = addMarkHamill (mock)
+      val r2 = mock.put (
+          "/actor/1",
+          headers = Map (ContentType -> MediaType.Json),
+          body = markHammer)
+      r2.code should be (Ok)
+      val etag = r2.etag
 
-    "GET /actor/1 with If-Modified-Since:0 should respond Ok" in
-      singlethreaded { implicit scheduler =>
+      val (t1, t2) = (r1.etag, r2.etag)
+      store.expectCells (PM.MovieTable) ()
+      store.expectCells (PM.CastTable) ()
+      store.expectCells (PM.ActorTable) (
+          ("1", t2, PO.markHammer),
+          ("1", t1, PO.markHamill))
+      store.expectCells (PM.RolesTable) (
+          ("1", t1, PM.Roles.empty))
+      store.expectCells (PM.Index) (
+          ("mark hamill", t2, None),
+          ("mark hamill", t1, PO.actors ("1")),
+          ("mark hammer", t2, PO.actors ("1")))
+    }
+
+    "PUT /actor/1 with a If-Unmodified-Since:1 should respond Ok with an etag" in {
+      val (store, mock) = setup()
+      val r1 = addMarkHamill (mock)
+      val r2 = mock.put (
+          "/actor/1",
+          headers = Map (ContentType -> MediaType.Json, IfUnmodifiedSince -> r1.etag.toString),
+          body = markHammer)
+      r2.code should be (Ok)
+
+      val (t1, t2) = (r1.etag, r2.etag)
+      store.expectCells (PM.MovieTable) ()
+      store.expectCells (PM.CastTable) ()
+      store.expectCells (PM.ActorTable) (
+          ("1", t2, PO.markHammer),
+          ("1", t1, PO.markHamill))
+      store.expectCells (PM.RolesTable) (
+          ("1", t1, PM.Roles.empty))
+      store.expectCells (PM.Index) (
+          ("mark hamill", t2, None),
+          ("mark hamill", t1, PO.actors ("1")),
+          ("mark hammer", t2, PO.actors ("1")))
+    }
+
+    "PUT /actor/1 with a If-Unmodified-Since:0 should respond Precondition Failed" in {
+      val (store, mock) = setup()
+      val r1 = addMarkHamill (mock)
+      val r2 = mock.put (
+          "/actor/1",
+          headers = Map (ContentType -> MediaType.Json, IfUnmodifiedSince -> "0"),
+          body = markHammer)
+      r2.code should be (PreconditionFailed)
+
+      val t1 = r1.etag
+      store.expectCells (PM.MovieTable) ()
+      store.expectCells (PM.CastTable) ()
+      store.expectCells (PM.ActorTable) (
+          ("1", t1, PO.markHamill))
+      store.expectCells (PM.RolesTable) (
+          ("1", t1, PM.Roles.empty))
+      store.expectCells (PM.Index) (
+          ("mark hamill", t1, PO.actors ("1")))
+    }
+
+    "GET /actor?q=mark should respond Okay" in {
         val (store, mock) = setup()
-        val r1 = addMarkHamill (mock)
-        val r2 = mock.get (
-            "/actor/1",
-            headers = Map (IfModifiedSince -> "0"))
-        r2.code should be (Ok)
-        r2.etag should be (r1.etag)
-        r2.body should matchJson (markHamill)
-      }
-
-    "GET /actor/1 with If-Modified-Since:(r1.etag) should respond Not Modified" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val r1 = addMarkHamill (mock)
-        val response = mock.get (
-            "/actor/1",
-            headers = Map (IfModifiedSince -> r1.etag.toString))
-        response.code should be (NotModified)
-        response.body should be ("")
-      }
-
-    "GET /actor/1 with Last-Modification-Before:(r1.etag-1) should respond Not Found" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val r1 = addMarkHamill (mock)
-        val response = mock.get (
-            "/actor/1",
-            headers = Map (LastModificationBefore -> (r1.etag-1).toString))
-        response.code should be (NotFound)
-      }
-
-    "GET /actor/1 with Last-Modification-Before:(r1.etag) should respond Ok" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val r1 = addMarkHamill (mock)
-        val r2 = mock.get (
-            "/actor/1",
-            headers = Map (LastModificationBefore -> r1.etag.toString))
-        r2.code should be (Ok)
-        r2.etag should be (r1.etag)
-        r2.body should matchJson (markHamill)
-      }
-
-    "PUT /actor/1 with should respond Ok with an etag" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val r1 = addMarkHamill (mock)
-        val r2 = mock.put (
-            "/actor/1",
-            headers = Map (ContentType -> MediaType.Json),
-            body = markHammer)
-        r2.code should be (Ok)
-        val etag = r2.etag
-
-        val (t1, t2) = (r1.etag, r2.etag)
-        store.expectCells (PM.MovieTable) ()
-        store.expectCells (PM.CastTable) ()
-        store.expectCells (PM.ActorTable) (
-            ("1", t2, PO.markHammer),
-            ("1", t1, PO.markHamill))
-        store.expectCells (PM.RolesTable) (
-            ("1", t1, PM.Roles.empty))
-        store.expectCells (PM.Index) (
-            ("mark hamill", t2, None),
-            ("mark hamill", t1, PO.actors ("1")),
-            ("mark hammer", t2, PO.actors ("1")))
-      }
-
-    "PUT /actor/1 with a If-Unmodified-Since:1 should respond Ok with an etag" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val r1 = addMarkHamill (mock)
-        val r2 = mock.put (
-            "/actor/1",
-            headers = Map (ContentType -> MediaType.Json, IfUnmodifiedSince -> r1.etag.toString),
-            body = markHammer)
-        r2.code should be (Ok)
-
-        val (t1, t2) = (r1.etag, r2.etag)
-        store.expectCells (PM.MovieTable) ()
-        store.expectCells (PM.CastTable) ()
-        store.expectCells (PM.ActorTable) (
-            ("1", t2, PO.markHammer),
-            ("1", t1, PO.markHamill))
-        store.expectCells (PM.RolesTable) (
-            ("1", t1, PM.Roles.empty))
-        store.expectCells (PM.Index) (
-            ("mark hamill", t2, None),
-            ("mark hamill", t1, PO.actors ("1")),
-            ("mark hammer", t2, PO.actors ("1")))
-      }
-
-    "PUT /actor/1 with a If-Unmodified-Since:0 should respond Precondition Failed" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val r1 = addMarkHamill (mock)
-        val r2 = mock.put (
-            "/actor/1",
-            headers = Map (ContentType -> MediaType.Json, IfUnmodifiedSince -> "0"),
-            body = markHammer)
-        r2.code should be (PreconditionFailed)
-
-        val t1 = r1.etag
-        store.expectCells (PM.MovieTable) ()
-        store.expectCells (PM.CastTable) ()
-        store.expectCells (PM.ActorTable) (
-            ("1", t1, PO.markHamill))
-        store.expectCells (PM.RolesTable) (
-            ("1", t1, PM.Roles.empty))
-        store.expectCells (PM.Index) (
-            ("mark hamill", t1, PO.actors ("1")))
-      }
-
-    "GET /actor?q=mark should respond Okay" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val r1 = addMarkHamill (mock)
-        val response = mock.get ("/actor?q=mark")
-        response.code should equal (Ok)
-        response.body should matchJson (s"""{
-          "movies": [],
-          "actors": [{"id": "1", "name": "Mark Hamill"}]
-        }""")
-      }}}
+      val r1 = addMarkHamill (mock)
+      val response = mock.get ("/actor?q=mark")
+      response.code should equal (Ok)
+      response.body should matchJson (s"""{
+        "movies": [],
+        "actors": [{"id": "1", "name": "Mark Hamill"}]
+      }""")
+    }}}

--- a/examples/movies/server/test/movies/MovieResourceSpec.scala
+++ b/examples/movies/server/test/movies/MovieResourceSpec.scala
@@ -18,21 +18,19 @@ package movies
 
 import scala.util.Random
 
-import com.treode.async.stubs.StubScheduler
 import com.treode.store.stubs.StubStore
 import com.twitter.finagle.http.MediaType
 import com.twitter.finatra.test.MockApp
 import org.scalatest.{FreeSpec, Matchers}
 
 import movies.{PhysicalModel => PM}
-import StubScheduler.singlethreaded
 
 class MovieResourceSpec extends FreeSpec with Matchers with ResourceSpecTools {
 
   val starWars = """{"id": "1", "title": "Star Wars", "released": null, "cast": []}"""
   val aNewHope = """{"id": "1", "title": "Star Wars: A New Hope", "released": null, "cast": []}"""
 
-  def setup () (implicit scheduler: StubScheduler) = {
+  def setup () = {
     implicit val random = Random
     implicit val store = StubStore()
     val movies = new MovieStore
@@ -52,206 +50,192 @@ class MovieResourceSpec extends FreeSpec with Matchers with ResourceSpecTools {
 
   "When the database is empty" - {
 
-    "GET /movie/1 should respond Not Found" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val response = mock.get ("/movie/1")
-        response.code should equal (NotFound)
-      }
+    "GET /movie/1 should respond Not Found" in {
+      val (store, mock) = setup()
+      val response = mock.get ("/movie/1")
+      response.code should equal (NotFound)
+    }
 
-    "PUT /movie/1 should respond Ok with an etag" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val r1 = addStarWars (mock)
+    "PUT /movie/1 should respond Ok with an etag" in {
+      val (store, mock) = setup()
+      val r1 = addStarWars (mock)
 
-        val t1 = r1.etag
-        store.expectCells (PM.MovieTable) (
-            ("1", t1, PO.starWars))
-        store.expectCells (PM.CastTable) (
-            ("1", t1, PM.Cast.empty))
-        store.expectCells (PM.ActorTable) ()
-        store.expectCells (PM.RolesTable) ()
-        store.expectCells (PM.Index) (
-            ("star wars", t1, PO.movies ("1")))
-      }
+      val t1 = r1.etag
+      store.expectCells (PM.MovieTable) (
+          ("1", t1, PO.starWars))
+      store.expectCells (PM.CastTable) (
+          ("1", t1, PM.Cast.empty))
+      store.expectCells (PM.ActorTable) ()
+      store.expectCells (PM.RolesTable) ()
+      store.expectCells (PM.Index) (
+          ("star wars", t1, PO.movies ("1")))
+    }
 
-    "POST /movie should respond Ok with an etag" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
+    "POST /movie should respond Ok with an etag" in {
+      val (store, mock) = setup()
 
-        val r1 = mock.post (
-            "/movie",
+      val r1 = mock.post (
+          "/movie",
+          headers = Map (ContentType -> MediaType.Json),
+          body = starWars)
+      r1.code should equal (Ok)
+
+      val uri = r1.getHeader (Location)
+      val id = uri.substring ("/movie/".length)
+      val r2 = mock.get (uri)
+      r2.etag should be (r1.etag)
+      r2.body should matchJson (s"""{"id":"$id","title":"Star Wars","released":null,"cast":[]}""")
+    }
+
+    "PUT /movie/1 without a title should respond Bad Requst" in {
+      val (store, mock) = setup()
+      val r1 = mock.put (
+            "/movie/1",
             headers = Map (ContentType -> MediaType.Json),
-            body = starWars)
-        r1.code should equal (Ok)
+            body = "{}")
+      r1.code should equal (BadRequest)
 
-        val uri = r1.getHeader (Location)
-        val id = uri.substring ("/movie/".length)
-        val r2 = mock.get (uri)
-        r2.etag should be (r1.etag)
-        r2.body should matchJson (s"""{"id":"$id","title":"Star Wars","released":null,"cast":[]}""")
-      }
+      store.expectCells (PM.MovieTable) ()
+      store.expectCells (PM.CastTable) ()
+      store.expectCells (PM.ActorTable) ()
+      store.expectCells (PM.RolesTable) ()
+      store.expectCells (PM.Index) ()
+    }
 
-    "PUT /movie/1 without a title should respond Bad Requst" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val r1 = mock.put (
-              "/movie/1",
-              headers = Map (ContentType -> MediaType.Json),
-              body = "{}")
-        r1.code should equal (BadRequest)
-
-        store.expectCells (PM.MovieTable) ()
-        store.expectCells (PM.CastTable) ()
-        store.expectCells (PM.ActorTable) ()
-        store.expectCells (PM.RolesTable) ()
-        store.expectCells (PM.Index) ()
-      }
-
-    "GET /movie?q=star should respond Okay" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val r1 = addStarWars (mock)
-        val response = mock.get ("/movie?q=star")
-        response.code should equal (Ok)
-        response.body should matchJson (s"""{"movies": [], "actors": []}""")
-      }}
+    "GET /movie?q=star should respond Okay" in {
+      val (store, mock) = setup()
+      val r1 = addStarWars (mock)
+      val response = mock.get ("/movie?q=star")
+      response.code should equal (Ok)
+      response.body should matchJson (s"""{"movies": [], "actors": []}""")
+    }}
 
   "When the database has a movie" - {
 
-    "GET /movie/1 should respond Ok" in
-      singlethreaded { implicit scheduler =>
+    "GET /movie/1 should respond Ok" in {
+      val (store, mock) = setup()
+      val r1 = addStarWars (mock)
+      val r2 = mock.get ("/movie/1")
+      r2.code should equal (Ok)
+      r2.etag should be (r1.etag)
+      r2.body should matchJson (starWars)
+    }
+
+    "GET /movie/1 with If-Modified-Since:0 should respond Ok" in {
+      val (store, mock) = setup()
+      val r1 = addStarWars (mock)
+      val r2 = mock.get (
+          "/movie/1",
+          headers = Map (IfModifiedSince -> "0"))
+      r2.code should equal (Ok)
+      r2.etag should be (r1.etag)
+      r2.body should matchJson (starWars)
+    }
+
+    "GET /movie/1 with If-Modified-Since:(r1.etag) should respond Not Modified" in {
+      val (store, mock) = setup()
+      val r1 = addStarWars (mock)
+      val response = mock.get (
+          "/movie/1",
+          headers = Map (IfModifiedSince -> r1.etag.toString))
+      response.code should equal (NotModified)
+      response.body should be ("")
+    }
+
+    "GET /movie/1 with Last-Modification-Before:(r1.etag-1) should respond Not Found" in {
+      val (store, mock) = setup()
+      val r1 = addStarWars (mock)
+      val response = mock.get (
+          "/movie/1",
+          headers = Map (LastModificationBefore -> (r1.etag-1).toString))
+      response.code should equal (NotFound)
+    }
+
+    "GET /movie/1 with Last-Modification-Before:(r1.etag) should respond Ok" in {
         val (store, mock) = setup()
-        val r1 = addStarWars (mock)
-        val r2 = mock.get ("/movie/1")
-        r2.code should equal (Ok)
-        r2.etag should be (r1.etag)
-        r2.body should matchJson (starWars)
-      }
+      val r1 = addStarWars (mock)
+      val r2 = mock.get (
+          "/movie/1",
+          headers = Map (LastModificationBefore -> r1.etag.toString))
+      r2.code should equal (Ok)
+      r2.etag should be (r1.etag)
+      r2.body should matchJson (starWars)
+    }
 
-    "GET /movie/1 with If-Modified-Since:0 should respond Ok" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val r1 = addStarWars (mock)
-        val r2 = mock.get (
-            "/movie/1",
-            headers = Map (IfModifiedSince -> "0"))
-        r2.code should equal (Ok)
-        r2.etag should be (r1.etag)
-        r2.body should matchJson (starWars)
-      }
+    "PUT /movie/1 with should respond Ok with an etag" in {
+      val (store, mock) = setup()
+      val r1 = addStarWars (mock)
+      val r2 = mock.put (
+          "/movie/1",
+          headers = Map (ContentType -> MediaType.Json),
+          body = aNewHope)
+      r2.code should equal (Ok)
+      val etag = r2.etag
 
-    "GET /movie/1 with If-Modified-Since:(r1.etag) should respond Not Modified" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val r1 = addStarWars (mock)
-        val response = mock.get (
-            "/movie/1",
-            headers = Map (IfModifiedSince -> r1.etag.toString))
-        response.code should equal (NotModified)
-        response.body should be ("")
-      }
+      val (t1, t2) = (r1.etag, r2.etag)
+      store.expectCells (PM.MovieTable) (
+          ("1", t2, PO.aNewHope),
+          ("1", t1, PO.starWars))
+      store.expectCells (PM.CastTable) (
+          ("1", t1, PM.Cast.empty))
+      store.expectCells (PM.ActorTable) ()
+      store.expectCells (PM.RolesTable) ()
+      store.expectCells (PM.Index) (
+          ("star wars", t2, None),
+          ("star wars", t1, PO.movies ("1")),
+          ("star wars: a new hope", t2, PO.movies ("1")))
+    }
 
-    "GET /movie/1 with Last-Modification-Before:(r1.etag-1) should respond Not Found" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val r1 = addStarWars (mock)
-        val response = mock.get (
-            "/movie/1",
-            headers = Map (LastModificationBefore -> (r1.etag-1).toString))
-        response.code should equal (NotFound)
-      }
+    "PUT /movie/1 with a If-Unmodified-Since:1 should respond Ok with an etag" in {
+      val (store, mock) = setup()
+      val r1 = addStarWars (mock)
+      val r2 = mock.put (
+          "/movie/1",
+          headers = Map (ContentType -> MediaType.Json, IfUnmodifiedSince -> r1.etag.toString),
+          body = aNewHope)
+      r2.code should equal (Ok)
 
-    "GET /movie/1 with Last-Modification-Before:(r1.etag) should respond Ok" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val r1 = addStarWars (mock)
-        val r2 = mock.get (
-            "/movie/1",
-            headers = Map (LastModificationBefore -> r1.etag.toString))
-        r2.code should equal (Ok)
-        r2.etag should be (r1.etag)
-        r2.body should matchJson (starWars)
-      }
+      val (t1, t2) = (r1.etag, r2.etag)
+      store.expectCells (PM.MovieTable) (
+          ("1", t2, PO.aNewHope),
+          ("1", t1, PO.starWars))
+      store.expectCells (PM.CastTable) (
+          ("1", t1, PM.Cast.empty))
+      store.expectCells (PM.ActorTable) ()
+      store.expectCells (PM.RolesTable) ()
+      store.expectCells (PM.Index) (
+          ("star wars", t2, None),
+          ("star wars", t1, PO.movies ("1")),
+          ("star wars: a new hope", t2, PO.movies ("1")))
+    }
 
-    "PUT /movie/1 with should respond Ok with an etag" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val r1 = addStarWars (mock)
-        val r2 = mock.put (
-            "/movie/1",
-            headers = Map (ContentType -> MediaType.Json),
-            body = aNewHope)
-        r2.code should equal (Ok)
-        val etag = r2.etag
+    "PUT /movie/1 with a If-Unmodified-Since:0 should respond Precondition Failed" in {
+      val (store, mock) = setup()
+      val r1 = addStarWars (mock)
+      val r2 = mock.put (
+          "/movie/1",
+          headers = Map (ContentType -> MediaType.Json, IfUnmodifiedSince -> "0"),
+          body = aNewHope)
+      r2.code should equal (PreconditionFailed)
 
-        val (t1, t2) = (r1.etag, r2.etag)
-        store.expectCells (PM.MovieTable) (
-            ("1", t2, PO.aNewHope),
-            ("1", t1, PO.starWars))
-        store.expectCells (PM.CastTable) (
-            ("1", t1, PM.Cast.empty))
-        store.expectCells (PM.ActorTable) ()
-        store.expectCells (PM.RolesTable) ()
-        store.expectCells (PM.Index) (
-            ("star wars", t2, None),
-            ("star wars", t1, PO.movies ("1")),
-            ("star wars: a new hope", t2, PO.movies ("1")))
-      }
+      val t1 = r1.etag
+      store.expectCells (PM.MovieTable) (
+          ("1", t1, PO.starWars))
+      store.expectCells (PM.CastTable) (
+          ("1", t1, PM.Cast.empty))
+      store.expectCells (PM.ActorTable) ()
+      store.expectCells (PM.RolesTable) ()
+      store.expectCells (PM.Index) (
+          ("star wars", t1, PO.movies ("1")))
+    }
 
-    "PUT /movie/1 with a If-Unmodified-Since:1 should respond Ok with an etag" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val r1 = addStarWars (mock)
-        val r2 = mock.put (
-            "/movie/1",
-            headers = Map (ContentType -> MediaType.Json, IfUnmodifiedSince -> r1.etag.toString),
-            body = aNewHope)
-        r2.code should equal (Ok)
-
-        val (t1, t2) = (r1.etag, r2.etag)
-        store.expectCells (PM.MovieTable) (
-            ("1", t2, PO.aNewHope),
-            ("1", t1, PO.starWars))
-        store.expectCells (PM.CastTable) (
-            ("1", t1, PM.Cast.empty))
-        store.expectCells (PM.ActorTable) ()
-        store.expectCells (PM.RolesTable) ()
-        store.expectCells (PM.Index) (
-            ("star wars", t2, None),
-            ("star wars", t1, PO.movies ("1")),
-            ("star wars: a new hope", t2, PO.movies ("1")))
-      }
-
-    "PUT /movie/1 with a If-Unmodified-Since:0 should respond Precondition Failed" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val r1 = addStarWars (mock)
-        val r2 = mock.put (
-            "/movie/1",
-            headers = Map (ContentType -> MediaType.Json, IfUnmodifiedSince -> "0"),
-            body = aNewHope)
-        r2.code should equal (PreconditionFailed)
-
-        val t1 = r1.etag
-        store.expectCells (PM.MovieTable) (
-            ("1", t1, PO.starWars))
-        store.expectCells (PM.CastTable) (
-            ("1", t1, PM.Cast.empty))
-        store.expectCells (PM.ActorTable) ()
-        store.expectCells (PM.RolesTable) ()
-        store.expectCells (PM.Index) (
-            ("star wars", t1, PO.movies ("1")))
-      }
-
-    "GET /movie?q=star should respond Okay" in
-      singlethreaded { implicit scheduler =>
-        val (store, mock) = setup()
-        val r1 = addStarWars (mock)
-        val response = mock.get ("/movie?q=star")
-        response.code should equal (Ok)
-        response.body should matchJson (s"""{
-          "movies": [{"movieId": "1", "title": "Star Wars"}],
-          "actors": []
-        }""")
-      }}}
+    "GET /movie?q=star should respond Okay" in {
+      val (store, mock) = setup()
+      val r1 = addStarWars (mock)
+      val response = mock.get ("/movie?q=star")
+      response.code should equal (Ok)
+      response.body should matchJson (s"""{
+        "movies": [{"movieId": "1", "title": "Star Wars"}],
+        "actors": []
+      }""")
+    }}}

--- a/examples/movies/server/test/movies/ResourceSpecTools.scala
+++ b/examples/movies/server/test/movies/ResourceSpecTools.scala
@@ -17,14 +17,14 @@
 package movies
 
 import com.fasterxml.jackson.databind.JsonNode
+import com.treode.async.stubs.ProvidedSingleThreadScheduler
 import com.treode.store.TxClock
 import com.twitter.finatra.test.MockResult
-import org.scalatest.Assertions
+import org.scalatest.Suite
 import org.scalatest.matchers.{Matcher, MatchResult}
 
-trait ResourceSpecTools extends SpecTools {
-  this: Assertions =>
-
+trait ResourceSpecTools extends SpecTools with ProvidedSingleThreadScheduler {
+  this: Suite =>
 
   class JsonMatcher (expected: String) extends Matcher [String] {
 


### PR DESCRIPTION
Using an executor per test would consume too many JVM resources. After running tests several times from SBT, exceptions would be thrown.
