### PR TITLE
Use grunt-install-dependencies to automatically manage grunt deps.

### DIFF
--- a/scripts/build-merge
+++ b/scripts/build-merge
@@ -32,7 +32,7 @@
 # person.
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-: ${SBT:='scripts/sbt'}
+: ${SBT:=${DIR}'/scripts/sbt'}
 : ${GRUNT:='grunt'}
 LOG=$DIR/build.log
 

--- a/scripts/build-pull-request
+++ b/scripts/build-pull-request
@@ -26,7 +26,7 @@
 # 3) Builds and tests the examples using the locally published libraries.
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-: ${SBT:='scripts/sbt'}
+: ${SBT:=${DIR}'/scripts/sbt'}
 : ${GRUNT:='grunt'}
 LOG=$DIR/build.log
 


### PR DESCRIPTION
Use SBT environment variable in case the user needs to use a different sbt from /scripts/sbt.
Use ${SBT} instead of scripts/sbt.
