### PR TITLE
Report host and cell as stored in disk.

### DIFF
--- a/cluster/src/com/treode/cluster/Listener.scala
+++ b/cluster/src/com/treode/cluster/Listener.scala
@@ -84,7 +84,7 @@ private class Listener (
   def startup() {
     server = ServerSocket.open (group)
     server.bind (localAddr)
-    log.acceptingConnections (localId, localAddr)
+    log.acceptingConnections (cellId, localId, localAddr)
     loop()
   }
 

--- a/cluster/src/com/treode/cluster/package.scala
+++ b/cluster/src/com/treode/cluster/package.scala
@@ -40,8 +40,8 @@ package object cluster {
 
     val logger = Logger.getLogger ("com.treode.cluster")
 
-    def acceptingConnections (localId: HostId, localAddr: SocketAddress): Unit =
-      logger.log (INFO, s"Accepting peer connections to $localId on $localAddr")
+    def acceptingConnections (cellid: CellId, localId: HostId, localAddr: SocketAddress): Unit =
+      logger.log (INFO, s"Accepting peer connections to $localId for $cellid on $localAddr")
 
     def connected (remoteId: HostId, localAddr: SocketAddress, remoteAddr: SocketAddress): Unit =
       logger.log (INFO, s"Connected to $remoteId at $localAddr : $remoteAddr")


### PR DESCRIPTION
Reporting the host and cell makes easier to fire another host, hail and join the cohort or simply migrate the disk.
