### PR TITLE
The default store recovery should take scheduler as a parameter.

### DIFF
--- a/async/src/com/treode/async/Globals.scala
+++ b/async/src/com/treode/async/Globals.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 Treode, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.treode.async
+
+import java.util.concurrent.{Executors, ScheduledExecutorService}
+import scala.concurrent.ExecutionContext
+
+object Globals {
+
+  /** A default ScheduledExecutorService. */
+  val executor: ScheduledExecutorService =
+    Executors.newScheduledThreadPool (Runtime.getRuntime.availableProcessors)
+
+  /** A default Scheduler that uses the default executor. */
+  implicit val scheduler: Scheduler =
+    Scheduler (executor)
+
+  /** A default ExecutionContext that uses the default executor. */
+  implicit val executionContext: ExecutionContext =
+    ExecutionContext.fromExecutorService (executor)
+}

--- a/async/stub/com/treode/async/stubs/StubScheduler.scala
+++ b/async/stub/com/treode/async/stubs/StubScheduler.scala
@@ -64,7 +64,7 @@ object StubScheduler {
     Executors.newScheduledThreadPool (Runtime.getRuntime.availableProcessors)
 
   /** A default StubScheduler that uses the default executor. */
-  implicit val scheduler =
+  implicit val scheduler: StubScheduler =
     StubScheduler.wrapped (executor)
 
   /** A default ExecutionContext that uses the default executor. */

--- a/store/src/com/treode/store/ExtendedController.scala
+++ b/store/src/com/treode/store/ExtendedController.scala
@@ -18,7 +18,6 @@ package com.treode.store
 
 import java.net.SocketAddress
 import java.nio.file.Path
-import java.util.concurrent.ExecutorService
 
 import com.treode.async.Async
 import com.treode.cluster.{CellId, Cluster, HostId, Peer, RumorDescriptor}
@@ -27,7 +26,6 @@ import com.treode.disk.{Disk, DriveAttachment, DriveDigest}
 import Async.guard
 
 private class ExtendedController (
-    executor: ExecutorService,
     disk: Disk.Controller,
     cluster: Cluster,
     controller: Store.Controller
@@ -86,6 +84,4 @@ private class ExtendedController (
         _ <- cluster.shutdown()
         _ <- disk.shutdown()
       } yield ()
-    } .ensure {
-      executor.shutdownNow()
     }}

--- a/twitter-util/src/com/treode/twitter/app/StoreKit.scala
+++ b/twitter-util/src/com/treode/twitter/app/StoreKit.scala
@@ -20,6 +20,7 @@ import java.net.{InetAddress, InetSocketAddress}
 import java.nio.file.Paths
 import scala.reflect.ClassTag
 
+import com.treode.async.{Globals, Scheduler}
 import com.treode.cluster.{Cluster, HostId}
 import com.treode.disk.Disk
 import com.treode.store.{Cohort, Store}
@@ -108,6 +109,8 @@ trait StoreKit {
     }
     paths = args
   }
+
+  implicit val scheduler: Scheduler = Globals.scheduler
 
   lazy val controller = {
 


### PR DESCRIPTION
The default method for recovering a store built a scheduler, but then it wasn't available to the user. Now the method takes a scheduler as a parameter. For convenience, this adds a Globals object with a scheduler, and it adds an implicit scheduler in the StoreKit.
