### PR TITLE
Have BatchIterator iterate A rather than Seq [A].

### DIFF
--- a/async/src/com/treode/async/AsyncIterator.scala
+++ b/async/src/com/treode/async/AsyncIterator.scala
@@ -51,6 +51,13 @@ trait AsyncIterator [A] {
   def withFilter (p: A => Boolean): AsyncIterator [A] =
     filter (p)
 
+  /** A BatchIterator of sequences of one element. */
+  def batch: BatchIterator [A] =
+    new BatchIterator [A] {
+      def batch (f: Iterator [A] => Async [Unit]): Async [Unit] =
+        self.foreach (x => f (Iterator (x)))
+    }
+
   /** Execute the asynchronous operation `f` foreach element while `p` is true.  Return the first
     * element for which `p` fails, or `None` if `p` never fails and the whole sequence is
     * consumed.

--- a/async/test/com/treode/async/AsyncIteratorPerf.scala
+++ b/async/test/com/treode/async/AsyncIteratorPerf.scala
@@ -43,8 +43,8 @@ class AsyncIteratorPerf extends PerformanceTest.Quickbenchmark {
   // os-name: Mac OS X
   //
   // Parameters(size -> 1000): 0.003
-  // Parameters(size -> 10000): 0.036
-  // Parameters(size -> 100000): 0.357
+  // Parameters(size -> 10000): 0.034
+  // Parameters(size -> 100000): 0.342
   performance of "while (baseline)" in {
     using (lists) in { list =>
       var count = 0
@@ -56,10 +56,10 @@ class AsyncIteratorPerf extends PerformanceTest.Quickbenchmark {
       count
     }}
 
-  // About 2-3x vs while.
-  // Parameters(size -> 1000): 0.007
-  // Parameters(size -> 10000): 0.105
-  // Parameters(size -> 100000): 0.92
+  // About 2x vs while.
+  // Parameters(size -> 1000): 0.006
+  // Parameters(size -> 10000): 0.06
+  // Parameters(size -> 100000): 0.604
   performance of "for" in {
     using (lists) in { xs =>
       var count = 0
@@ -67,10 +67,10 @@ class AsyncIteratorPerf extends PerformanceTest.Quickbenchmark {
       count
     }}
 
-  // About 10-30x vs for.
-  // Parameters(size -> 1000): 0.226
-  // Parameters(size -> 10000): 1.134
-  // Parameters(size -> 100000): 10.491
+  // About 15x vs for.
+  // Parameters(size -> 1000): 0.19
+  // Parameters(size -> 10000): 0.959
+  // Parameters(size -> 100000): 9.013
   performance of "async" in {
     using (lists) in { xs =>
       implicit val scheduler = StubScheduler.random()
@@ -79,22 +79,22 @@ class AsyncIteratorPerf extends PerformanceTest.Quickbenchmark {
       count
     }}
 
-  // About 2-3x vs for.
-  // Parameters(size -> 1000): 0.132
-  // Parameters(size -> 10000): 0.326
-  // Parameters(size -> 100000): 2.236
+  // About 3-5x vs for.
+  // Parameters(size -> 1000): 0.108
+  // Parameters(size -> 10000): 0.254
+  // Parameters(size -> 100000): 1.646
   performance of "batch" in {
     using (lists) in { xs =>
       implicit val scheduler = StubScheduler.random()
       var count = 0
-      xs.batch.foreach (list => supply (list.foreach ((_: Int) => count += 1))) .expectPass()
+      xs.batch.foreach ((_: Int) => count += 1) .expectPass()
       count
     }}
 
-  // About 10-30x vs for.
-  // Parameters(size -> 1000): 0.228
-  // Parameters(size -> 10000): 1.144
-  // Parameters(size -> 100000): 10.565
+  // About 15x vs for.
+  // Parameters(size -> 1000): 0.191
+  // Parameters(size -> 10000): 0.938
+  // Parameters(size -> 100000): 8.641
   performance of "batch.flatten" in {
     using (lists) in { xs =>
       implicit val scheduler = StubScheduler.random()

--- a/store/src/com/treode/store/tier/TierIterator.scala
+++ b/store/src/com/treode/store/tier/TierIterator.scala
@@ -33,7 +33,7 @@ private abstract class TierIterator (
     disk: Disk
 ) extends CellIterator2 {
 
-  class Foreach (f: Iterator [Cell] => Async [Unit], cb: Callback [Unit]) {
+  class Batch (f: Iterator [Cell] => Async [Unit], cb: Callback [Unit]) {
 
     import desc.pager
 
@@ -156,8 +156,8 @@ private object TierIterator {
       disk: Disk
   ) extends TierIterator (desc, root) {
 
-    def foreach (f: Iterator [Cell] => Async [Unit]): Async [Unit] =
-      async (new Foreach (f, _) .start())
+    def batch (f: Iterator [Cell] => Async [Unit]): Async [Unit] =
+      async (new Batch (f, _) .start())
   }
 
   class FromKey (
@@ -168,8 +168,8 @@ private object TierIterator {
       disk: Disk
   ) extends TierIterator (desc, root) {
 
-    def foreach (f: Iterator [Cell] => Async [Unit]): Async [Unit] =
-      async (new Foreach (f, _) .start (start))
+    def batch (f: Iterator [Cell] => Async [Unit]): Async [Unit] =
+      async (new Batch (f, _) .start (start))
   }
 
   def apply (

--- a/store/test/com/treode/store/atomic/TestableCluster.scala
+++ b/store/test/com/treode/store/atomic/TestableCluster.scala
@@ -20,7 +20,6 @@ import scala.util.Random
 
 import com.treode.async.Async
 import com.treode.async.stubs.StubScheduler
-import com.treode.cluster.HostId
 import com.treode.cluster.stubs.StubNetwork
 import com.treode.store._
 


### PR DESCRIPTION
The BatchIterator should be a Scala Monad on elements (A) rather than sequences of elements (Seq [A]). The filter method provided the key insight. It was

```
def filter (p: Seq [A] => Boolean)
```

It could only remove whole sequences. This CL changes it to

```
def filter (p: A => Boolean)
```

It can now remove individual elements.
