### PR TITLE
Add streaming analytics.

### DIFF
--- a/examples/movies/README.md
+++ b/examples/movies/README.md
@@ -430,10 +430,20 @@ Run the Spark shell.
 
     spark-shell --jars spark/target/scala-2.10/movies-spark.jar
 
-Finally, run your queries.
+At Spark's prompt, run your queries.
 
-    scala> val ms = movies.MoviesRDD.movies (sc, "http://<your-host>/db/", 1)
-    scala> ms.count()
+    import movies._
+    val ms = sc.movies (sc, "http://<your-host>/db/", 1)
+    ms.count()
+    
+Or, run a stream processor.
+
+    import org.apache.spark.streaming._
+    import movies._
+    val ssc = new StreamingContext (sc, Seconds (15))
+    val ms = ssc.movies ("http://<your-host>/db/", 1)
+    ms.print()
+    ssc.start()
 
 
 

--- a/examples/movies/project/MoviesBuild.scala
+++ b/examples/movies/project/MoviesBuild.scala
@@ -94,9 +94,11 @@ object MoviesBuild extends Build {
 
       libraryDependencies ++= Seq (
         "org.apache.spark" %% "spark-core" % "1.1.0" % "provided",
+        "org.apache.spark" %% "spark-streaming" % "1.1.0" % "provided",
         // Use Jackson 2.3.1 because spark-core does.
         "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % "2.3.1",
-        "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.3.1"),
+        "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.3.1",
+        "org.scalatest" %% "scalatest" % "2.2.2" % "test"),
 
       jarName in assembly := "movies-spark.jar",
 

--- a/examples/movies/server/src/movies/AnalyticsResource.scala
+++ b/examples/movies/server/src/movies/AnalyticsResource.scala
@@ -29,8 +29,7 @@ object AnalyticsResource {
     router.register ("/rdd/actors") { request =>
       request.method match {
         case Method.Get =>
-          val rt = request.lastModificationBefore
-          supply (respond.json (request, PM.Actor.list (rt)))
+          supply (respond.json (request, PM.Actor.list (request.window)))
         case _ =>
           supply (respond (request, Status.MethodNotAllowed))
       }}
@@ -38,8 +37,7 @@ object AnalyticsResource {
     router.register ("/rdd/movies") { request =>
       request.method match {
         case Method.Get =>
-          val rt = request.lastModificationBefore
-          supply (respond.json (request, PM.Movie.list (rt)))
+          supply (respond.json (request, PM.Movie.list (request.window)))
         case _ =>
           supply (respond (request, Status.MethodNotAllowed))
       }}
@@ -47,8 +45,7 @@ object AnalyticsResource {
     router.register ("/rdd/roles") { request =>
       request.method match {
         case Method.Get =>
-          val rt = request.lastModificationBefore
-          supply (respond.json (request, PM.Roles.list (rt)))
+          supply (respond.json (request, PM.Roles.list (request.window)))
         case _ =>
           supply (respond (request, Status.MethodNotAllowed))
       }}}}

--- a/examples/movies/server/src/movies/PhysicalModel.scala
+++ b/examples/movies/server/src/movies/PhysicalModel.scala
@@ -119,10 +119,10 @@ private object PhysicalModel {
             .async()
       } yield ()
 
-    def list (rt: TxClock) (implicit store: Store): BatchIterator [AM.Movie] =
+    def list (window: Window) (implicit store: Store): BatchIterator [AM.Movie] =
       for {
         cell <- MovieTable.scan (
-            window = Window.Latest (rt, true), 
+            window = window, 
             batch = Batch (4000, 1 << 18))
         if cell.value.isDefined
       } yield {
@@ -340,10 +340,10 @@ private object PhysicalModel {
             .async()
       } yield ()
 
-    def list (rt: TxClock) (implicit store: Store): BatchIterator [AM.Actor] =
+    def list (window: Window) (implicit store: Store): BatchIterator [AM.Actor] =
       for {
         cell <- ActorTable.scan (
-            window = Window.Latest (rt, true), 
+            window = window, 
             batch = Batch (4000, 1 << 18))
         if cell.value.isDefined
       } yield {
@@ -449,10 +449,10 @@ private object PhysicalModel {
 
     val empty = Roles (Seq.empty)
 
-    def list (rt: TxClock) (implicit store: Store): BatchIterator [AM.Role] =
+    def list (window: Window) (implicit store: Store): BatchIterator [AM.Role] =
       for {
         cell <- RolesTable.scan (
-            window = Window.Latest (rt, true),  
+            window = window,  
             batch = Batch (4000, 1 << 18))
         if cell.value.isDefined
         val actorId = cell.key

--- a/examples/movies/server/src/movies/package.scala
+++ b/examples/movies/server/src/movies/package.scala
@@ -150,10 +150,8 @@ package object movies {
 
   implicit class RichRequest (request: Request) extends http.RichRequest (request) {
 
-    def id (prefix: String): String = {
+    def id (prefix: String): String =
       request.path.substring (prefix.length)
-
-    }
 
     def pretty: Boolean =
       // If the accept header lacks "application/json", then pretty print the response.

--- a/examples/movies/spark/src/movies/MoviesDBatch.scala
+++ b/examples/movies/spark/src/movies/MoviesDBatch.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 Treode, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package movies
+
+import java.net.{URI, URL}
+import scala.reflect.ClassTag
+
+import org.apache.spark.SparkContext
+
+private class MoviesDBatch [T: ClassTag] (
+  sc: SparkContext,
+  uri: URI,
+  nslices: Int,
+  since: Long,
+  until: Long
+) extends MoviesRDD [T] (sc, uri, nslices) {
+
+  override def url (slice: Int): URL =
+    urlOfWindow (uri, slice, nslices, since, until)
+}

--- a/examples/movies/spark/src/movies/MoviesDStream.scala
+++ b/examples/movies/spark/src/movies/MoviesDStream.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 Treode, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package movies
+
+import java.lang.Integer.highestOneBit
+import java.net.URI
+import scala.reflect.ClassTag
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.streaming.{StreamingContext, Time}
+import org.apache.spark.streaming.dstream.InputDStream
+
+private class MoviesDStream [T: ClassTag] (
+  _ssc: StreamingContext,
+  uri: URI,
+  nslices: Int
+) extends InputDStream [T] (_ssc) {
+
+  require (nslices == highestOneBit (nslices), "Number of slices must be a power of two.")
+
+  @volatile private var lastTime: Time = new Time (0)
+
+  def start(): Unit = ()
+
+  def stop(): Unit = ()
+
+  def compute (time: Time): Option [RDD [T]] = {
+    val since = lastTime.milliseconds * 1000
+    val until = time.milliseconds * 1000
+    val batch = new MoviesDBatch [T] (_ssc.sparkContext, uri, nslices, since, until)
+    lastTime = time
+    Some (batch)
+  }}

--- a/examples/movies/spark/src/movies/package.scala
+++ b/examples/movies/spark/src/movies/package.scala
@@ -14,10 +14,17 @@
  * limitations under the License.
  */
 
+import java.net.{URI, URL}
+
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.joda.JodaModule
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import org.apache.spark.{Partition => SparkPartition}
+import org.apache.spark.{Partition => SparkPartition, SparkContext}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.streaming.StreamingContext
+import org.apache.spark.streaming.dstream.DStream
+
+import movies.{AnalyticsModel => AM}
 
 package object movies {
 
@@ -26,4 +33,77 @@ package object movies {
   private [movies] val textJson = new ObjectMapper
   textJson.registerModule (DefaultScalaModule)
   textJson.registerModule (new JodaModule)
-}
+
+  private [movies] def urlOfPartition (uri: URI, slice: Int, nslices: Int): URL = {
+    assert (0 <= slice && slice < nslices)
+    val ident = new URI (
+      uri.getScheme,
+      uri.getUserInfo,
+      uri.getHost,
+      uri.getPort,
+      uri.getPath,
+      s"slice=$slice&nslices=$nslices", // query
+      uri.getFragment)
+    ident.toURL
+  }
+
+  private [movies] def urlOfWindow (uri: URI, slice: Int, nslices: Int, since: Long, until: Long): URL = {
+    assert (0 <= slice && slice < nslices)
+    val ident = new URI (
+      uri.getScheme,
+      uri.getUserInfo,
+      uri.getHost,
+      uri.getPort,
+      uri.getPath,
+      s"slice=$slice&nslices=$nslices&since=$since&until=$until", // query
+      uri.getFragment)
+    ident.toURL
+  }
+
+  private [movies] def resolve (base: URI, path: String): URI =
+    if (base.getPath == "")
+      base.resolve ("/") .resolve (path)
+    else
+      base.resolve (path)
+
+  implicit class RichSparkContext (sc: SparkContext) {
+
+    def movies (base: URI, nslices: Int): RDD [AM.Movie] =
+      new MoviesRDD (sc, resolve (base, "rdd/movies"), nslices)
+
+    def movies (base: String, nslices: Int): RDD [AM.Movie] =
+      movies (new URI (base), nslices)
+
+    def actors (base: URI, nslices: Int): RDD [AM.Actor] =
+      new MoviesRDD (sc, resolve (base, "rdd/actors"), nslices)
+
+    def actors (base: String, nslices: Int): RDD [AM.Actor] =
+      actors (new URI (base), nslices)
+
+    def roles (base: URI, nslices: Int): RDD [AM.Role] =
+      new MoviesRDD (sc, resolve (base, "rdd/roles"), nslices)
+
+    def roles (base: String, nslices: Int): RDD [AM.Role] =
+      roles (new URI (base), nslices)
+  }
+
+  implicit class RichStreamingContext (ssc: StreamingContext) {
+
+    def movies (base: URI, nslices: Int): DStream [AM.Movie] =
+      new MoviesDStream (ssc, resolve (base, "rdd/movies"), nslices)
+
+    def movies (base: String, nslices: Int): DStream [AM.Movie] =
+      movies (new URI (base), nslices)
+
+    def actors (base: URI, nslices: Int): DStream [AM.Actor] =
+      new MoviesDStream (ssc, resolve (base, "rdd/actors"), nslices)
+
+    def actors (base: String, nslices: Int): DStream [AM.Actor] =
+      actors (new URI (base), nslices)
+
+    def roles (base: URI, nslices: Int): DStream [AM.Role] =
+      new MoviesDStream (ssc, resolve (base, "rdd/roles"), nslices)
+
+    def roles (base: String, nslices: Int): DStream [AM.Role] =
+      roles (new URI (base), nslices)
+  }}

--- a/examples/movies/spark/test/movies/PackageSpec.scala
+++ b/examples/movies/spark/test/movies/PackageSpec.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 Treode, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package movies
+
+import java.net.URI
+
+import org.scalatest.FlatSpec
+
+class PackageSpec extends FlatSpec {
+
+  "urlOfPartition" should "work" in {
+    assertResult ("http://example.com?slice=3&nslices=8") {
+      urlOfPartition (new URI ("http://example.com"), 3, 8) .toString
+    }}
+
+  "urlOfWidnow" should "work" in {
+    assertResult ("http://example.com?slice=3&nslices=8&since=100&until=200") {
+      urlOfWindow (new URI ("http://example.com"), 3, 8, 100, 200) .toString
+    }}}

--- a/store/src/com/treode/store/Window.scala
+++ b/store/src/com/treode/store/Window.scala
@@ -27,6 +27,8 @@ package com.treode.store
 sealed abstract class Window {
 
   def later: Bound [TxClock]
+  
+  def overlaps (latest: TxClock, earliest: TxClock): Boolean
 
   def filter: Cell => Boolean
 }
@@ -42,6 +44,9 @@ object Window {
 
   /** Choose only the latest value as of `later` so long as that was set after `earlier`. */
   case class Latest (later: Bound [TxClock], earlier: Bound [TxClock]) extends Window {
+
+    def overlaps (latest: TxClock, earliest: TxClock): Boolean =
+      earlier <* latest && later >* earliest
 
     def filter: Cell => Boolean =
       new Function [Cell, Boolean] {
@@ -87,6 +92,9 @@ object Window {
   /** Choose all changes between `later` and `earlier`. */
   case class Between (later: Bound [TxClock], earlier: Bound [TxClock]) extends Window {
 
+    def overlaps (latest: TxClock, earliest: TxClock): Boolean =
+      earlier <* latest && later >* earliest
+
     def filter: Cell => Boolean =
       new Function [Cell, Boolean] {
         def apply (cell: Cell): Boolean =
@@ -103,6 +111,9 @@ object Window {
     * `earlier`.
     */
   case class Through (later: Bound [TxClock], earlier: TxClock) extends Window {
+
+    def overlaps (latest: TxClock, earliest: TxClock): Boolean =
+      later >* earliest
 
     def filter: Cell => Boolean =
       new Function [Cell, Boolean] {

--- a/store/src/com/treode/store/atomic/TimedStore.scala
+++ b/store/src/com/treode/store/atomic/TimedStore.scala
@@ -110,10 +110,7 @@ private class TimedStore (kit: AtomicKit) extends PageHandler [Long] {
       for {
         _ <- space.scan (window.later.bound)
       } yield {
-        getTable (table)
-            .iterator (start, library.residents)
-            .slice (table, slice)
-            .window (window)
+        getTable (table) .iterator (start, window, slice, library.residents)
       }}
 
   def receive (table: TableId, cells: Seq [Cell]): Async [Unit] = {

--- a/store/src/com/treode/store/tier/SynthTable.scala
+++ b/store/src/com/treode/store/tier/SynthTable.scala
@@ -164,6 +164,20 @@ private class SynthTable (
         .clean (desc, id, residents)
   }
 
+  def iterator (start: Bound [Key], window: Window, slice: Slice, residents: Residents): CellIterator2 = {
+    readLock.lock()
+    val (primary, secondary, tiers) = try {
+      (this.primary, this.secondary, this.tiers)
+    } finally {
+      readLock.unlock()
+    }
+    TierIterator
+        .merge (desc, start, primary, secondary, tiers.overlaps (window))
+        .clean (desc, id, residents)
+        .slice (id, slice)
+        .window (window)
+  }
+
   def receive (cells: Seq [Cell]): (Long, Seq [Cell]) = {
     readLock.lock()
     try {

--- a/store/src/com/treode/store/tier/Tier.scala
+++ b/store/src/com/treode/store/tier/Tier.scala
@@ -84,6 +84,9 @@ private case class Tier (
           cb.fail (t)
       }}
 
+  def overlaps (window: Window): Boolean =
+    window.overlaps (latest, earliest)
+
   def estimate (other: Residents): Long =
     (keys.toDouble * residents.stability (other) * 1.1).toLong
 

--- a/store/src/com/treode/store/tier/TierTable.scala
+++ b/store/src/com/treode/store/tier/TierTable.scala
@@ -63,6 +63,8 @@ private [store] trait TierTable {
 
   def iterator (start: Bound [Key], residents: Residents): CellIterator2
 
+  def iterator (start: Bound [Key], window: Window, slice: Slice, residents: Residents): CellIterator2
+
   /** Put a key.
     *
     * @return The generation. The client must log this key piece of data, and provide it to the

--- a/store/src/com/treode/store/tier/Tiers.scala
+++ b/store/src/com/treode/store/tier/Tiers.scala
@@ -17,7 +17,7 @@
 package com.treode.store.tier
 
 import com.treode.disk.Position
-import com.treode.store.{Residents, Store, StorePicklers, TableDigest}
+import com.treode.store.{Residents, Store, StorePicklers, TableDigest, Window}
 
  private case class Tiers (tiers: Seq [Tier]) {
 
@@ -29,6 +29,9 @@ import com.treode.store.{Residents, Store, StorePicklers, TableDigest}
 
   def isEmpty: Boolean =
     tiers.isEmpty
+
+  def overlaps (window: Window): Tiers =
+    Tiers (tiers.filter (_.overlaps (window)))
 
   def maxGen: Long =
     if (tiers.isEmpty) 0 else tiers.head.gen


### PR DESCRIPTION
Add a Spark DStream for movies, actors and roles. This requires carrying window parameters through the URI and down to the scan. Fix the scan to filter unneeded tiers so that it doesn't bother reading their disk pages.
