### PR TITLE
Undeprecate AsyncIterator.

### DIFF
--- a/async/src/com/treode/async/AsyncIterator.scala
+++ b/async/src/com/treode/async/AsyncIterator.scala
@@ -23,8 +23,14 @@ import com.treode.async.implicits._
 
 import Async.{async, supply, when}
 
-/** Concrete classes should implement `foreach`. */
-@deprecated ("use BatchIterator", "0.2.0")
+/** Concrete classes should implement `foreach`.
+  *
+  * You should consider using BatchIterator whenever possible. This places a task on the scheduler
+  * foreach element, and that can adds overhead. If you must do some asynchronous task for every
+  * element, you will incur that overhead anyway, so the point is moot, and this interface will be
+  * more convenient. On the other hand, if you can do that asynchronous task for a batch of items,
+  * you can save that overhead by using BatchIterator.
+  */
 trait AsyncIterator [A] {
   self =>
 

--- a/async/src/com/treode/async/BatchIterator.scala
+++ b/async/src/com/treode/async/BatchIterator.scala
@@ -25,7 +25,13 @@ import com.treode.async.implicits._
 
 import Async.{async, guard, supply, when}
 
-/** Concrete classes should implement `batch`. */
+/** Iterate batches of items asynchronously.
+  *
+  * Compare to [[AsyncIterator]]. The `foreach` and `whilst` methods here take a plain old
+  * function, whereas those methods in AsyncIterator take an asynchronous function.
+  *
+  * Concrete classes should implement `batch`.
+  */
 trait BatchIterator [A] {
   self =>
 
@@ -76,24 +82,7 @@ trait BatchIterator [A] {
     *   - [[AsyncIterator#toSeqWhile]]
     */
   def flatten (implicit scheduler: Scheduler): AsyncIterator [A] =
-    new AsyncIterator [A] {
-
-      def foreach (f: A => Async [Unit]): Async [Unit] =
-        self.batch (_.async.foreach (f))
-
-      override def toMap [K, V] (implicit witness: <:< [A, (K, V)]): Async [Map [K, V]] =
-        self.toMap
-
-      override def toMapWhile [K, V] (p: A => Boolean) (implicit witness: <:< [A, (K, V)]):
-          Async [(Map [K, V], Option [A])] =
-        self.toMapWhile (p)
-
-      override def toSeq: Async [Seq [A]] =
-        self.toSeq
-
-      override def toSeqWhile (p: A => Boolean): Async [(Seq [A], Option [A])] =
-        self.toSeqWhile (p)
-    }
+    new AsyncIterator [A] (self)
 
   /** Execute the operation `f` foreach element while `p` is true.  Return the first element for
     * which `p` fails, or `None` if `p` never fails and the whole sequence is consumed.

--- a/async/src/com/treode/async/implicits/package.scala
+++ b/async/src/com/treode/async/implicits/package.scala
@@ -94,7 +94,7 @@ package object implicits {
       */
     def rescue (f: PartialFunction [Throwable, Try [A]]): Callback [A] =
       (v => cb (v recoverWith f))
-}
+  }
 
   implicit class RichIterator [A] (iter: Iterator [A]) {
 

--- a/async/stub/com/treode/async/stubs/CallbackCaptor.scala
+++ b/async/stub/com/treode/async/stubs/CallbackCaptor.scala
@@ -115,8 +115,8 @@ class CallbackCaptor [T] private extends (Try [T] => Unit) with Assertions {
   /** Run until the callback has been invoked, then assert that it yielded
     * [[scala.util.Success Success]] and return the result.
     */
-  def expectPass () (implicit scheduler: StubScheduler): T = {
-    scheduler.run (timers = !wasInvoked)
+  def expectPass () (implicit s: StubScheduler): T = {
+    s.run (timers = !wasInvoked)
     assertPassed
   }
 

--- a/async/stub/com/treode/async/stubs/implicits/package.scala
+++ b/async/stub/com/treode/async/stubs/implicits/package.scala
@@ -16,7 +16,7 @@
 
 package com.treode.async.stubs
 
-import com.treode.async.{Async, AsyncIterator}
+import com.treode.async.Async
 import org.scalatest.Assertions
 
 import Assertions.assertResult

--- a/async/stub/com/treode/async/stubs/implicits/package.scala
+++ b/async/stub/com/treode/async/stubs/implicits/package.scala
@@ -39,7 +39,7 @@ package object implicits {
       * [[scala.util.Success Success]] and return the result.
       */
     def expectPass () (implicit scheduler: StubScheduler): A =
-      capture() .expectPass
+      capture() .expectPass()
 
     /** Run until the asynchronous operation completes, then assert that it yielded
       * [[scala.util.Success Failure]] and assert that the result is as expected.

--- a/async/test/com/treode/async/AsyncIteratorSpec.scala
+++ b/async/test/com/treode/async/AsyncIteratorSpec.scala
@@ -16,394 +16,142 @@
 
 package com.treode.async
 
-import com.treode.async.implicits._
 import com.treode.async.stubs.StubScheduler
 import com.treode.async.stubs.implicits._
-import org.scalatest.FlatSpec
+import org.scalatest.FreeSpec
 
-import Async.supply
+import Async.{guard, supply, when}
 import AsyncIteratorTestTools._
 
-class AsyncIteratorSpec extends FlatSpec {
+class AsyncIteratorSpec extends FreeSpec {
 
-  private def map [A, B] (xs: A*) (f: A => B) (implicit s: StubScheduler): AsyncIterator [B] =
-    xs.async.map (f)
+  "foreach should" - {
 
-  private def flatMap [A, B] (xs: A*) (ys: B*) (implicit s: StubScheduler): AsyncIterator [(A, B)] =
-    xs.async.flatMap (x => ys.async.map (y => (x, y)))
-
-  private def filter [A] (xs: A*) (p: A => Boolean) (implicit s: StubScheduler): AsyncIterator [A] =
-    xs.async.filter (p)
-
-  private def whilst [A] (xs: A*) (p: A => Boolean) (f: A => Any) (implicit s: StubScheduler): Option [A] =
-    xs.async.whilst (p) (x => supply (f (x))) .expectPass()
-
-  "AsyncIterator.foreach" should "handle an empty sequence" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq () (Seq.empty.async)
-  }
-
-  it should "handle a sequence of one element" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq (1) (adapt (1))
-  }
-
-  it should "handle a sequence of three elements" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq (1, 2, 3) (adapt (1, 2, 3))
-  }
-
-  it should "stop at the first exception" in {
-    implicit val scheduler = StubScheduler.random()
-    var consumed = Set.empty [Int]
-    var provided = Set.empty [Int]
-    assertFail [DistinguishedException] {
-      val i1 = track (adapt (1, 2, 3, 4)) (consumed += _)
-      val i2 = failWhen (i1) (_ == 3)
-      track (i2) (provided += _)
+    "work with the for keyword" in {
+      val xs = Seq.newBuilder [Int]
+      implicit val scheduler = StubScheduler.random()
+      val task = for (x <- flatten (items)) supply (xs += x)
+      task.expectPass()
+      assertResult (items.flatten) (xs.result)
     }
-    assertResult (Set (1, 2, 3)) (consumed)
-    assertResult (Set (1, 2)) (provided)
-  }
 
-  it should "work with the for keyword" in {
-    val xs = Seq.newBuilder [Int]
-    implicit val scheduler = StubScheduler.random()
-    val task =
-      for (x <- adapt (1, 2, 3))
-        supply (xs += x)
-    task.expectPass()
-    assertResult (Seq (1, 2, 3)) (xs.result)
-  }
+    "handle various batches" in {
 
-  "AsyncIterator.map" should "handle an empty sequence" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq () (map [Int, Int] () (_ * 2))
-  }
-
-  it should "handle a sequence of one element" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq (2) (map (1) (_ * 2))
-  }
-
-  it should "handle a sequence of three elements" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq (2, 4, 6) (map (1, 2, 3) (_ * 2))
-  }
-
-  it should "stop at the first exception from the input iterator" in {
-    implicit val scheduler = StubScheduler.random()
-    var consumed = Set.empty [Int]
-    var provided = Set.empty [Int]
-    assertFail [DistinguishedException] {
-      val i1 = track (adapt (1, 2, 3, 4)) (consumed += _)
-      val i2 = failWhen (i1) (_ == 3)
-      val i3 = i2 map (_ * 2)
-      track (i3) (provided += _)
-    }
-    assertResult (Set (1, 2, 3)) (consumed)
-    assertResult (Set (2, 4)) (provided)
-  }
-
-  it should "work with the for keyword" in {
-    implicit val scheduler = StubScheduler.random()
-    val iter = for (x <- adapt (1, 2, 3)) yield x * 2
-    assertSeq (2, 4, 6) (iter)
-  }
-
-  "AsyncIterator.flatMap" should "handle empty sequences" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq () (flatMap [Int, Int] () (1, 2, 3))
-  }
-
-  it should "handle an empty outer sequence" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq () (flatMap [Int, Int] () (1, 2, 3))
-  }
-
-  it should "handle an empty inner sequence" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq () (flatMap [Int, Int] (1, 2, 3) ())
-  }
-
-  it should "handle an outer sequence of 1" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq ((1, 1), (1, 2), (1, 3)) (flatMap [Int, Int] (1) (1, 2, 3))
-  }
-
-  it should "handle an inner sequence of 1" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq ((1, 1), (2, 1), (3, 1)) (flatMap [Int, Int] (1, 2, 3) (1))
-  }
-
-  it should "handle an both sequences of three" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq ((1,1), (1,2), (1,3), (2,1), (2,2), (2,3), (3,1), (3,2), (3,3)) {
-      flatMap [Int, Int] (1, 2, 3) (1, 2, 3)
-    }}
-
-  it should "stop at the first exception from the outer iterator" in {
-    implicit val scheduler = StubScheduler.random()
-    var consumed = Set.empty [Int]
-    var provided = Set.empty [(Int, Int)]
-    assertFail [DistinguishedException] {
-      val i1 = track (adapt (1, 2, 3, 4)) (consumed += _)
-      val i2 = failWhen (i1) (_ == 3)
-      val i3 = i2 flatMap (x => adapt (1) map (y => (x, y)))
-      track (i3) (provided += _)
-    }
-    assertResult (Set (1, 2, 3)) (consumed)
-    assertResult (Set ((1, 1), (2, 1))) (provided)
-  }
-
-  it should "stop at the first exception from the inner iterator" in {
-    implicit val scheduler = StubScheduler.random()
-    var consumed = Set.empty [Int]
-    var provided = Set.empty [(Int, Int)]
-    assertFail [DistinguishedException] {
-      val i1 = track (adapt (1, 2, 3, 4)) (consumed += _)
-      val i2 = failWhen (i1) (_ == 3)
-      val i3 = adapt (1, 2, 3) flatMap (x => i2 map (y => (x, y)))
-      track (i3) (provided += _)
-    }
-    assertResult (Set (1, 2, 3)) (consumed)
-    assertResult (Set ((1, 1), (1, 2))) (provided)
-  }
-
-  "AsyncIterator.filter" should "handle [] -> []" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq () (filter [Int] () (_ => false))
-  }
-
-  it should "handle [1] -> []" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq () (filter [Int] () (_ => false))
-  }
-
-  it should "handle [1] -> [1]" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq (1) (filter (1) (_ => true))
-  }
-
-  it should "handle [1, 2] -> []" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq () (filter (1, 2) (_ => false))
-  }
-
-  it should "handle [1, 2] -> [1, 2]" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq (1, 2) (filter (1, 2) (_ => true))
-  }
-
-  it should "handle [1, 2] -> [1]" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq (1) (filter (1, 2) (i => (i & 1) == 1))
-  }
-
-  it should "handle [1, 2] -> [2]" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq (2) (filter (1, 2) (i => (i & 1) == 0))
-  }
-
-  it should "handle [1, 2, 3] -> []" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq () (filter (1, 2, 3) (_ => false))
-  }
-
-  it should "handle [1, 2, 3] -> [1, 2, 3]" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq (1, 2, 3) (filter (1, 2, 3) (_ => true))
-  }
-
-  it should "handle [1, 2, 3] -> [2]" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq (2) (filter (1, 2, 3) (i => (i & 1) == 0))
-  }
-
-  it should "handle [1, 2, 3] -> [1, 3]" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq (1, 3) (filter (1, 2, 3) (i => (i & 1) == 1))
-  }
-
-  it should "handle [1, 2, 3] -> [1, 2]" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq (1, 2) (filter (1, 2, 3) (_ < 3))
-  }
-
-  it should "handle [1, 2, 3] -> [2, 3]" in {
-    implicit val scheduler = StubScheduler.random()
-    assertSeq (2, 3) (filter (1, 2, 3) (_ > 1))
-  }
-
-  it should "stop at the first exception from the input iterator" in {
-    implicit val scheduler = StubScheduler.random()
-    var consumed = Set.empty [Int]
-    var provided = Set.empty [Int]
-    assertFail [DistinguishedException] {
-      val i1 = track (adapt (1, 2, 3, 4)) (consumed += _)
-      val i2 = failWhen (i1) (_ == 3)
-      val i3 = i2.filter (i => (i & 1) == 1)
-      track (i3) (provided += _)
-    }
-    assertResult (Set (1, 2, 3)) (consumed)
-    assertResult (Set (1)) (provided)
-  }
-
-  it should "work with the for keyword" in {
-    implicit val scheduler = StubScheduler.random()
-    val iter =
-      for (x <- adapt (1, 2, 3, 4); if (x & 1) == 0) yield x
-    assertSeq (2, 4) (iter)
-  }
-
-  "AsyncIterator.whilst" should "stop when the condition fails before the iterator stops" in {
-    implicit val scheduler = StubScheduler.random()
-    var seen = Set.empty [Int]
-    val last = whilst (1, 2, 3) (_ < 3) (seen += _)
-    assertResult (Set (1, 2)) (seen)
-    assertResult (Some (3)) (last)
-  }
-
-  it should "stop when the input iterator stops before the condition fails" in {
-    implicit val scheduler = StubScheduler.random()
-    var seen = Set.empty [Int]
-    val last = whilst (1, 2, 3) (_ < 4) (seen += _)
-    assertResult (Set (1, 2, 3)) (seen)
-    assertResult (None) (last)
-  }
-
-  it should "stop when the condition fails immediately" in {
-    implicit val scheduler = StubScheduler.random()
-    var seen = Set.empty [Int]
-    val last = whilst (1, 2, 3) (_ < 0) (seen += _)
-    assertResult (Set.empty) (seen)
-    assertResult (Some (1)) (last)
-  }
-
-  it should "handle an empty input iterator when the condition passes" in {
-    implicit val scheduler = StubScheduler.random()
-    var seen = Set.empty [Int]
-    val last = whilst () (_ => true) (seen += _)
-    assertResult (Set.empty) (seen)
-    assertResult (None) (last)
-  }
-
-  it should "handle an empty input iterator when the condition fails" in {
-    implicit val scheduler = StubScheduler.random()
-    var seen = Set.empty [Int]
-    val last = whilst () (_ => false) (seen += _)
-    assertResult (Set.empty) (seen)
-    assertResult (None) (last)
-  }
-
-  it should "stop at the first exception from the input iterator" in {
-    implicit val scheduler = StubScheduler.random()
-    var consumed = Set.empty [Int]
-    var seen = Set.empty [Int]
-    val i1 = track (adapt (1, 2, 3, 4)) (consumed += _)
-    val i2 = failWhen (i1) (_ == 3)
-    i2.whilst (_ < 5) (x => supply (seen += x)) .fail [DistinguishedException]
-    assertResult (Set (1, 2, 3)) (consumed)
-    assertResult (Set (1, 2)) (seen)
-  }
-
-  it should "stop at the first exception thrown from the predicate" in {
-    implicit val scheduler = StubScheduler.random()
-    var consumed = Set.empty [Int]
-    var seen = Set.empty [Int]
-    val i1 = track (adapt (1, 2, 3, 4)) (consumed += _)
-    i1.whilst { x =>
-      if (x == 3) throw new DistinguishedException
-      x < 5
-    } (x => supply (seen += x)) .fail [DistinguishedException]
-    assertResult (Set (1, 2, 3)) (consumed)
-    assertResult (Set (1, 2)) (seen)
-  }
-
-  it should "stop at the first exception thrown from the body" in {
-    implicit val scheduler = StubScheduler.random()
-    var consumed = Set.empty [Int]
-    var seen = Set.empty [Int]
-    val i1 = track (adapt (1, 2, 3, 4)) (consumed += _)
-    i1.whilst (_ < 5) { x =>
-      if (x == 3) throw new DistinguishedException
-      supply (seen += x)
-    } .fail [DistinguishedException]
-    assertResult (Set (1, 2, 3)) (consumed)
-    assertResult (Set (1, 2)) (seen)
-  }
-
-  it should "stop at the first exception returned from the body" in {
-    implicit val scheduler = StubScheduler.random()
-    var consumed = Set.empty [Int]
-    var seen = Set.empty [Int]
-    val i1 = track (adapt (1, 2, 3, 4)) (consumed += _)
-    i1.whilst (_ < 5) { x =>
-      supply {
-        if (x == 3) throw new DistinguishedException
-        seen += x
+      def test (items: Seq [Seq [Int]]) {
+        implicit val scheduler = StubScheduler.random()
+        val builder = Seq.newBuilder [Int]
+        flatten (items) .foreach (x => supply (builder += x)) .expectPass()
+        assertResult (items.flatten) (builder.result)
       }
-    } .fail [DistinguishedException]
-    assertResult (Set (1, 2, 3)) (consumed)
-    assertResult (Set (1, 2)) (seen)
-  }
 
-  "AsyncIterator.toMap" should "build the elements into a map" in {
-    implicit val scheduler = StubScheduler.random()
-    assertResult (Map.empty) {
-      adapt() .toMap.expectPass()
+      forAll (test)
     }
-    assertResult (Map (1 -> 10)) {
-      adapt (1 -> 10) .toMap.expectPass()
-    }
-    assertResult (Map (1 -> 10, 2 -> 20)) {
-      adapt (1 -> 10, 2 -> 20) .toMap.expectPass()
-    }
-    assertResult (Map (1 -> 10, 2 -> 20, 3 -> 30)) {
-      adapt (1 -> 10, 2 -> 20, 3 -> 30) .toMap.expectPass()
+
+    "pass through an exception" in {
+      implicit val scheduler = StubScheduler.random()
+      guard {
+        for (x <- flatten (items))
+          when (x == 3) (throw new DistinguishedException)
+      } .fail [DistinguishedException]
     }}
 
-  "AsyncIterator.toMapWhile" should "build the initial elements into a map" in {
-    implicit val scheduler = StubScheduler.random()
-    assertResult ((Map.empty, None)) {
-      adapt [(Int, Int)] () .toMapWhile (_._1 < 2) .expectPass()
-    }
-    assertResult ((Map (1 -> 10), None)) {
-      adapt (1 -> 10) .toMapWhile (_._1 < 2) .expectPass()
-    }
-    assertResult ((Map (1 -> 10), Some (2 -> 20))) {
-      adapt (1 -> 10, 2 -> 20) .toMapWhile (_._1 < 2) .expectPass()
-    }
-    assertResult ((Map (1 -> 10), Some (2 -> 20))) {
-      adapt (1 -> 10, 2 -> 20, 3 -> 30) .toMapWhile (_._1 < 2) .expectPass()
+  "map should" - {
+
+    "work with the for keyword" in {
+      implicit val scheduler = StubScheduler.random()
+      val iter = for (x <- flatten (items)) yield x * 2
+      assertSeq (items.flatten.map (_ * 2)) (iter)
     }}
 
-  "AsyncIterator.toSeq" should "build the elements into a sequence" in {
-    implicit val scheduler = StubScheduler.random()
-    assertResult (Seq.empty) {
-      adapt() .toSeq.expectPass()
-    }
-    assertResult (Seq (1)) {
-      adapt (1) .toSeq.expectPass()
-    }
-    assertResult (Seq (1, 2)) {
-      adapt (1, 2) .toSeq.expectPass()
-    }
-    assertResult (Seq (1, 2, 3)) {
-      adapt (1, 2, 3) .toSeq.expectPass()
+
+  "flatMap should" - {
+
+    val inner = Seq (1, 2, 3)
+
+    "work with the for keyword" in {
+      implicit val scheduler = StubScheduler.random()
+      val iter = for (x <- flatten (items); y <- flatten (Seq (inner))) yield (x, y)
+      val expected = for (x <- items.flatten; y <- inner) yield (x, y)
+      assertSeq (expected) (iter)
     }}
 
-  "AsyncIterator.toSeqWhile" should "build the initial elements into a sequence" in {
-    implicit val scheduler = StubScheduler.random()
-    assertResult ((Seq.empty, None)) {
-      adapt [Int] () .toSeqWhile (_ < 2) .expectPass()
+  "filter should" - {
+
+    "work with the for keyword" in {
+      implicit val scheduler = StubScheduler.random()
+      val iter = for (x <- flatten (items); if isOdd (x)) yield x
+      assertSeq (items.flatten.filter (isOdd _)) (iter)
+    }}
+
+  "whilst should" - {
+
+    def whilst (xs: Seq [Seq [Int]]) (p: Int => Boolean) (f: Int => Any) (implicit s: StubScheduler) =
+      flatten (xs) .whilst (p) (x => supply (f (x)))
+
+    "handle an empty input iterator" in {
+      implicit val scheduler = StubScheduler.random()
+      var seen = Set.empty [Int]
+      val last = whilst (Seq.empty) (_ => true) (seen += _) .expectPass()
+      assertResult (Set.empty) (seen)
+      assertResult (None) (last)
     }
-    assertResult ((Seq (1), None)) {
-      adapt (1) .toSeqWhile (_ < 2) .expectPass()
+
+    "stop when the condition fails immediately" in {
+      implicit val scheduler = StubScheduler.random()
+      var seen = Set.empty [Int]
+      val last = whilst (items) (_ < 0) (seen += _) .expectPass()
+      assertResult (Set.empty) (seen)
+      assertResult (Some (1)) (last)
     }
-    assertResult ((Seq (1), Some (2))) {
-      adapt (1, 2) .toSeqWhile (_ < 2) .expectPass()
+
+    "stop when the condition fails before the iterator stops" in {
+      implicit val scheduler = StubScheduler.random()
+      var seen = Set.empty [Int]
+      val last = whilst (items) (_ < 3) (seen += _) .expectPass()
+      assertResult (Set (1, 2)) (seen)
+      assertResult (Some (3)) (last)
     }
-    assertResult ((Seq (1), Some (2))) {
-      adapt (1, 2, 3) .toSeqWhile (_ < 2) .expectPass()
+
+    "stop when the input iterator stops before the condition fails" in {
+      implicit val scheduler = StubScheduler.random()
+      var seen = Set.empty [Int]
+      val last = whilst (items) (_ < 6) (seen += _) .expectPass()
+      assertResult (Set (1, 2, 3, 4, 5)) (seen)
+      assertResult (None) (last)
+    }
+
+    "pass througn an exception from the input iterator" in {
+      implicit val scheduler = StubScheduler.random()
+      var seen = Set.empty [Int]
+      val iter =
+        for (x <- flatten (items)) yield
+          if (x == 3)
+            throw new DistinguishedException
+          else
+            x
+      iter.whilst (_ < 5) (x => supply (seen += x)) .fail [DistinguishedException]
+      assertResult (Set (1, 2)) (seen)
+    }
+
+    "pass througn an exception from the predicate" in {
+      implicit val scheduler = StubScheduler.random()
+      var seen = Set.empty [Int]
+      whilst (items) { x =>
+        if (x == 3)
+          throw new DistinguishedException
+        x < 5
+      } { x =>
+        supply (seen += x)
+      } .fail [DistinguishedException]
+      assertResult (Set (1, 2)) (seen)
+    }
+
+    "pass through an exception from the body" in {
+      implicit val scheduler = StubScheduler.random()
+      var seen = Set.empty [Int]
+      whilst (items) (_ < 5) { x =>
+        if (x == 3) throw new DistinguishedException
+        supply (seen += x)
+      } .fail [DistinguishedException]
+      assertResult (Set (1, 2)) (seen)
     }}}

--- a/async/test/com/treode/async/MergeIteratorSpec.scala
+++ b/async/test/com/treode/async/MergeIteratorSpec.scala
@@ -73,7 +73,7 @@ class MergeIteratorSpec extends FreeSpec with AsyncChecks {
     xsss.flatten.flatten.sorted
 
   def merge (xs: Seq [BatchIterator [Int]]) (implicit scheduler: StubScheduler) =
-    BatchIterator.merge (xs) (ordering, scheduler) .flatten.toSeq.expectPass()
+    BatchIterator.merge (xs) (ordering, scheduler) .toSeq.expectPass()
 
   def testStringOf [A] (xsss: Seq [Seq [Seq [A]]]): String =
     xsss.map (_.map (_.mkString ("[", ", ", "]")) .mkString ("[", ", ", "]")) .mkString ("; ")

--- a/disk/src/com/treode/disk/LogIterator.scala
+++ b/disk/src/com/treode/disk/LogIterator.scala
@@ -20,7 +20,7 @@ import java.nio.file.Path
 import java.util.ArrayDeque
 import scala.util.{Failure, Success}
 
-import com.treode.async.{Async, AsyncIterator, BatchIterator, Callback, Scheduler}
+import com.treode.async.{Async, BatchIterator, Callback, Scheduler}
 import com.treode.async.implicits._
 import com.treode.async.io.File
 import com.treode.buffer.PagedBuffer

--- a/disk/src/com/treode/disk/package.scala
+++ b/disk/src/com/treode/disk/package.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.ExecutorService
 import java.util.logging.{Level, Logger}
 
 import com.google.common.hash.Hashing
-import com.treode.async.{AsyncIterator, Scheduler}
+import com.treode.async.Scheduler
 import com.treode.async.io.File
 
 import Level.INFO
@@ -74,7 +74,6 @@ package object disk {
 
   private [disk] type LogDispatcher = Dispatcher [PickledRecord]
   private [disk] type PageDispatcher = Dispatcher [PickledPage]
-  private [disk] type ReplayIterator = AsyncIterator [(Long, Unit => Any)]
 
   private [disk] val checksum = Hashing.murmur3_32
 

--- a/disk/stub/com/treode/disk/stubs/StubDiskDrive.scala
+++ b/disk/stub/com/treode/disk/stubs/StubDiskDrive.scala
@@ -25,14 +25,14 @@ import com.treode.async.misc.RichOption
 import com.treode.buffer.ArrayBuffer
 import com.treode.disk.RecordRegistry
 
-import Async.async
+import Async.{async, supply}
 
 class StubDiskDrive (implicit random: Random) {
 
   private val stack = new ArrayDeque [Callback [Unit]]
   private var records = new ArrayList [Seq [StubRecord]]
   private var pages = Map.empty [Long, StubPage]
-  
+
   /** If true, the next call to `flush` or `fill` will be captured and push on a stack. */
   var stop: Boolean = false
 

--- a/store/src/com/treode/store/atomic/RecoveryKit.scala
+++ b/store/src/com/treode/store/atomic/RecoveryKit.scala
@@ -96,7 +96,7 @@ private class RecoveryKit (implicit
     kit.tstore.recover (tstore.close())
     val medics = writers.values
     for {
-      _ <- medics.filter (_.isCommitted) .async.foreach (_.close (kit))
+      _ <- medics.filter (_.isCommitted) .latch.unit.foreach (_.close (kit))
     } yield {
       medics.filter (_.isPrepared) .foreach (_.close (kit) .run (ignore))
       kit.reader.attach()

--- a/store/src/com/treode/store/package.scala
+++ b/store/src/com/treode/store/package.scala
@@ -20,7 +20,7 @@ import java.net.SocketAddress
 import java.util.concurrent.{TimeoutException => JTimeoutException}
 import java.util.logging.{Level, Logger}, Level.WARNING
 
-import com.treode.async.{Async, AsyncIterator, BatchIterator}
+import com.treode.async.{Async, BatchIterator}
 import com.treode.cluster.{RemoteException => CRemoteException, HostId, PortId}
 
 package store {

--- a/store/src/com/treode/store/tier/SynthTable.scala
+++ b/store/src/com/treode/store/tier/SynthTable.scala
@@ -19,7 +19,7 @@ package com.treode.store.tier
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import scala.collection.JavaConversions
 
-import com.treode.async.{Async, AsyncIterator, Callback, Scheduler}
+import com.treode.async.{Async, Callback, Scheduler}
 import com.treode.async.implicits._
 import com.treode.disk.{Disk, PageDescriptor, Position}
 import com.treode.store._

--- a/store/test/com/treode/store/StoreTestTools.scala
+++ b/store/test/com/treode/store/StoreTestTools.scala
@@ -20,7 +20,7 @@ import java.nio.file.{Path, Paths}
 import scala.language.implicitConversions
 import scala.util.Random
 
-import com.treode.async.{Async, AsyncIterator, BatchIterator}
+import com.treode.async.{Async, BatchIterator}
 import com.treode.async.stubs.{CallbackCaptor, StubScheduler}
 import com.treode.async.stubs.implicits._
 import com.treode.cluster.HostId

--- a/store/test/com/treode/store/atomic/AtomicBehaviors.scala
+++ b/store/test/com/treode/store/atomic/AtomicBehaviors.scala
@@ -27,7 +27,6 @@ import com.treode.store._
 import org.scalatest.FreeSpec
 
 import Async.supply
-import AtomicTestTools._
 import AtomicTracker._
 
 trait AtomicBehaviors extends CrashChecks with StoreClusterChecks {


### PR DESCRIPTION
It was a mistake to deprecate AsyncIterator, as there are cases where its useful. I kind of knew that, and was reminded why when I tried to pull it out. I cleaned up a few things in the process.
