### PR TITLE
Upgrade Finagle and use Scala 2.11 for Twitter Server.

### DIFF
--- a/examples/finagle/build.sbt
+++ b/examples/finagle/build.sbt
@@ -9,14 +9,14 @@ name := "finagle-example"
 
 version := "0.3.0-SNAPSHOT"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.4"
 
 libraryDependencies ++= Seq (
   "com.jayway.restassured" % "rest-assured" % "2.4.0" % "test",
   "com.treode" %% "jackson" % "0.3.0-SNAPSHOT",
   "com.treode" %% "store" % "0.3.0-SNAPSHOT" % "compile;test->stub",
   "com.treode" %% "twitter-server" % "0.3.0-SNAPSHOT",
-  "com.twitter" %% "finagle-http" % "6.22.0",
+  "com.twitter" %% "finagle-http" % "6.24.0",
   "org.scalatest" %% "scalatest" % "2.2.2" % "test")
 
 resolvers += "Twitter" at "http://maven.twttr.com"

--- a/examples/movies/project/MoviesBuild.scala
+++ b/examples/movies/project/MoviesBuild.scala
@@ -30,6 +30,7 @@ object MoviesBuild extends Build {
   val commonSettings = Seq (
 
       version := versionString,
+
       scalaVersion := "2.10.4",
 
       unmanagedSourceDirectories in Compile <<=
@@ -81,7 +82,7 @@ object MoviesBuild extends Build {
       test in assembly := {}
     )
 
-  // The Spark connector.
+  // The Spark connector; can be built with Scala 2.10 only.
   lazy val spark =
     Project ("spark", file ("spark"))
     .dependsOn (common)
@@ -93,8 +94,8 @@ object MoviesBuild extends Build {
       name := "movies-spark",
 
       libraryDependencies ++= Seq (
-        "org.apache.spark" %% "spark-core" % "1.1.0" % "provided",
-        "org.apache.spark" %% "spark-streaming" % "1.1.0" % "provided",
+        "org.apache.spark" %% "spark-core" % "1.2.0" % "provided",
+        "org.apache.spark" %% "spark-streaming" % "1.2.0" % "provided",
         // Use Jackson 2.3.1 because spark-core does.
         "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % "2.3.1",
         "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.3.1",

--- a/examples/unfiltered/build.sbt
+++ b/examples/unfiltered/build.sbt
@@ -9,7 +9,7 @@ organization := "com.treode"
 
 version := "0.3.0-SNAPSHOT"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.4"
 
 libraryDependencies ++= Seq (
   "com.jayway.restassured" % "rest-assured" % "2.4.0" % "test",

--- a/project/TreodeBuild.scala
+++ b/project/TreodeBuild.scala
@@ -238,14 +238,11 @@ object TreodeBuild extends Build {
     .settings (standardSettings: _*)
     .settings (
 
-        scalaVersion := "2.10.4",
-        crossScalaVersions := Seq.empty,
-
         resolvers += "Twitter" at "http://maven.twttr.com",
 
         libraryDependencies ++= Seq (
           "com.jayway.restassured" % "rest-assured" % "2.4.0" % "test",
-          "com.twitter" %% "twitter-server" % "1.8.0"))
+          "com.twitter" %% "twitter-server" % "1.9.0"))
 
   // A standalone server for system tests.  Separated to keep system testing components out of
   // production code (these components are in the default config in this project).
@@ -265,7 +262,7 @@ object TreodeBuild extends Build {
 
   lazy val copyDocAssetsTask = taskKey [Unit] ("Copy doc assets")
 
-  // The doc project includes everything for unidoc.
+  // The doc project includes everything.
   lazy val doc = Project ("doc", file ("doc"))
     .aggregate (buffer, pickle, async, cluster, disk, store, jackson, twitterServer)
     .settings (versionInfo: _*)
@@ -296,10 +293,9 @@ object TreodeBuild extends Build {
       publishLocal := {},
       publish := {})
 
-  // The root project includes everything that can be built across Scala versions; that is
-  // everything except Twitter Server, which can be built in 2.10 only.
+  // The root project includes everything.
   lazy val root = Project ("root", file ("."))
-    .aggregate (buffer, pickle, async, cluster, disk, store, jackson)
+    .aggregate (buffer, pickle, async, cluster, disk, store, jackson, twitterServer)
     .settings (versionInfo: _*)
     .settings (
 

--- a/scripts/build-functions.sh
+++ b/scripts/build-functions.sh
@@ -22,10 +22,6 @@
 : ${NPM:='npm'}
 : ${SBT:=${DIR}'/scripts/sbt'}
 
-# These must match the strings in crossScalaVersions of the SBT build configuration.
-: ${SCALA_2_11:='2.11.4'}
-: ${SCALA_2_10:='2.10.4'}
-
 #
 # Common Functions
 #

--- a/scripts/build-merge
+++ b/scripts/build-merge
@@ -63,12 +63,10 @@ log "Building $version"
 # Compile, and also publish locally for the examples below.
 echo-do ${SBT} +test:compile +publish-local
 
-# Twitter Server and Spark are available for Scala 2.10 only.
-echo-do ${SBT} ++${SCALA_2_10} twitter-server/test:compile twitter-server/publish-local
-
 # Skeleton examples.
 (cd examples/finagle; echo-do ${SBT} test:compile); expect-status 0
-(cd examples/finatra; echo-do ${SBT} test:compile); expect-status 0
+# Skip Finatra until it works with Twitter Server 1.9 (Finagle 6.24).
+#(cd examples/finatra; echo-do ${SBT} test:compile); expect-status 0
 (cd examples/unfiltered; echo-do ${SBT} test:compile); expect-status 0
 
 # Movies example; it has multiple components.
@@ -77,17 +75,17 @@ echo-do ${SBT} ++${SCALA_2_10} twitter-server/test:compile twitter-server/publis
 (cd examples/movies/webui; echo-do ${GRUNT} dist); expect-status 0
 
 # The documentation.
-echo-do ${SBT} ++${SCALA_2_10} doc/unidoc
+echo-do ${SBT} doc/unidoc
 
 #
 # Test
 #
 
-echo-do ${SBT} ++${SCALA_2_11} test intensive:test
-echo-do ${SBT} ++${SCALA_2_10} twitter-server/test
+echo-do ${SBT} test intensive:test
 
 (cd examples/finagle; echo-do ${SBT} test); expect-status 0
-(cd examples/finatra; echo-do ${SBT} test); expect-status 0
+# Skip Finatra until it works with Twitter Server 1.9 (Finagle 6.24).
+#(cd examples/finatra; echo-do ${SBT} test); expect-status 0
 (cd examples/unfiltered; echo-do ${SBT} test); expect-status 0
 (cd examples/movies; echo-do ${SBT} test); expect-status 0
 
@@ -97,25 +95,25 @@ echo-do ${SBT} ++${SCALA_2_10} twitter-server/test
 
 # Ivy artifacts.
 echo-do ${SBT} +publish
-echo-do ${SBT} ++${SCALA_2_10} publish twitter-server/publish
 
 # Finagle example.
 STAGE_FINAGLE=stage/examples/finagle/${version}
 (cd examples/finagle; echo-do ${SBT} assembly); expect-status 0
 echo-do mkdir -p ${STAGE_FINAGLE}
-echo-do cp examples/finagle/target/scala-2.10/finagle-server.jar ${STAGE_FINAGLE}/finagle-server-${version}.jar
+echo-do cp examples/finagle/target/scala-2.11/finagle-server.jar ${STAGE_FINAGLE}/finagle-server-${version}.jar
 
 # Finatra example.
-STAGE_FINATRA=stage/examples/finatra/${version}
-(cd examples/finatra; echo-do ${SBT} assembly); expect-status 0
-echo-do mkdir -p ${STAGE_FINATRA}
-echo-do cp examples/finatra/target/scala-2.10/finatra-server.jar ${STAGE_FINATRA}/finatra-server-${version}.jar
+# Skip Finatra until it works with Twitter Server 1.9 (Finagle 6.24).
+#STAGE_FINATRA=stage/examples/finatra/${version}
+#(cd examples/finatra; echo-do ${SBT} assembly); expect-status 0
+#echo-do mkdir -p ${STAGE_FINATRA}
+#echo-do cp examples/finatra/target/scala-2.10/finatra-server.jar ${STAGE_FINATRA}/finatra-server-${version}.jar
 
 # Unfiltered example.
 STAGE_UNFILTERED=stage/examples/unfiltered/${version}
 (cd examples/unfiltered; echo-do ${SBT} assembly); expect-status 0
 echo-do mkdir -p ${STAGE_UNFILTERED}
-echo-do cp examples/unfiltered/target/scala-2.10/unfiltered-server.jar ${STAGE_UNFILTERED}/unfiltered-server-${version}.jar
+echo-do cp examples/unfiltered/target/scala-2.11/unfiltered-server.jar ${STAGE_UNFILTERED}/unfiltered-server-${version}.jar
 
 # Movies example.
 STAGE_MOVIES=stage/examples/movies/${version}
@@ -127,7 +125,7 @@ echo-do cp examples/movies/spark/target/scala-2.10/movies-spark.jar ${STAGE_MOVI
 
 # Documentation.
 echo-do mkdir -p stage/docs/scala/store
-echo-do mv doc/target/scala-2.10/unidoc stage/docs/scala/store/${version}
+echo-do mv doc/target/scala-2.11/unidoc stage/docs/scala/store/${version}
 
 #
 # Done

--- a/scripts/build-pull-request
+++ b/scripts/build-pull-request
@@ -37,12 +37,10 @@ clean
 # Compile, and also publish locally for the examples below.
 echo-do ${SBT} +test:compile +publish-local
 
-# Twitter Server is available for Scala 2.10 only.
-echo-do ${SBT} ++${SCALA_2_10} twitter-server/test:compile twitter-server/publish-local
-
 # Skeleton examples.
 (cd examples/finagle; echo-do ${SBT} test:compile); expect-status 0
-(cd examples/finatra; echo-do ${SBT} test:compile); expect-status 0
+# Skip Finatra until it works with Twitter Server 1.9 (Finagle 6.24).
+#(cd examples/finatra; echo-do ${SBT} test:compile); expect-status 0
 (cd examples/unfiltered; echo-do ${SBT} test:compile); expect-status 0
 
 # Movies example; it has multiple components.
@@ -54,11 +52,11 @@ echo-do ${SBT} ++${SCALA_2_10} twitter-server/test:compile twitter-server/publis
 # Test
 #
 
-echo-do ${SBT} ++${SCALA_2_11} test intensive:test
-echo-do ${SBT} ++${SCALA_2_10} twitter-server/test
+echo-do ${SBT} test intensive:test
 
 (cd examples/finagle; echo-do ${SBT} test); expect-status 0
-(cd examples/finatra; echo-do ${SBT} test); expect-status 0
+# Skip Finatra until it works with Twitter Server 1.9 (Finagle 6.24).
+#(cd examples/finatra; echo-do ${SBT} test); expect-status 0
 (cd examples/unfiltered; echo-do ${SBT} test); expect-status 0
 (cd examples/movies; echo-do ${SBT} test); expect-status 0
 

--- a/twitter-server/src/com/treode/twitter/finagle/http/filter/BadRequestFilter.scala
+++ b/twitter-server/src/com/treode/twitter/finagle/http/filter/BadRequestFilter.scala
@@ -16,7 +16,6 @@
 
 package com.treode.twitter.finagle.http.filter
 
-import com.fasterxml.jackson.core.JsonProcessingException
 import com.treode.twitter.finagle.http.BadRequestException
 import com.twitter.finagle.{Service, SimpleFilter}
 import com.twitter.finagle.http.{Request, Response, Status}

--- a/twitter-server/src/com/treode/twitter/finagle/http/package.scala
+++ b/twitter-server/src/com/treode/twitter/finagle/http/package.scala
@@ -27,7 +27,6 @@ import com.treode.async.misc.{RichOption, parseInt}
 import com.treode.cluster.HostId
 import com.treode.jackson.DefaultTreodeModule
 import com.treode.store.{Slice, TxClock, TxId, Window}
-import com.treode.twitter.finagle.http.{BadRequestException, RichRequest}
 import com.treode.twitter.util.RichTwitterFuture
 import com.twitter.finagle.http.{MediaType, Request, Response, Status}
 import com.twitter.finagle.netty3.ChannelBufferBuf
@@ -81,7 +80,7 @@ package object http {
           writer.writeValue (stream, v)
         }
         stream.flush()
-        rsp.writer.write (ChannelBufferBuf (buffer)) .toAsync
+        rsp.writer.write (ChannelBufferBuf.Owned (buffer)) .toAsync
       } .flatMap { _ =>
         val buffer = ChannelBuffers.dynamicBuffer()
         val stream = new ChannelBufferOutputStream (buffer)
@@ -89,7 +88,7 @@ package object http {
           stream.writeByte ('[')
         stream.writeByte (']')
         stream.flush()
-        rsp.writer.write (ChannelBufferBuf (buffer)) .toAsync
+        rsp.writer.write (ChannelBufferBuf.Owned (buffer)) .toAsync
       } .run {
         case Success (_) =>
           rsp.close()

--- a/twitter-server/test/com/treode/twitter/server/handler/AtlasHandlerSpec.scala
+++ b/twitter-server/test/com/treode/twitter/server/handler/AtlasHandlerSpec.scala
@@ -40,7 +40,7 @@ class AtlasHandlerSpec extends FlatSpec with SpecTools {
 
   it should "handle PUT" in
     served { case (port, controller) =>
-      (controller.cohorts_= _) .expects (Seq.empty) .returning()
+      (controller.cohorts_= _) .expects (Seq.empty) .returning (())
       given
         .port (port)
         .body ("[]")

--- a/twitter-server/test/com/treode/twitter/server/handler/DrivesAttachHandlerSpec.scala
+++ b/twitter-server/test/com/treode/twitter/server/handler/DrivesAttachHandlerSpec.scala
@@ -28,7 +28,7 @@ class DrivesAttachHandlerSpec extends FlatSpec with SpecTools {
 
   "The DrivesAttachHandler" should "handle POST" in
     served { case (port, controller) =>
-      (controller.attach _) .expects (Seq.empty) .returning (supply())
+      (controller.attach _) .expects (Seq.empty) .returning (supply (()))
       given
         .port (port)
         .body ("[]")

--- a/twitter-server/test/com/treode/twitter/server/handler/DrivesDrainHandlerSpec.scala
+++ b/twitter-server/test/com/treode/twitter/server/handler/DrivesDrainHandlerSpec.scala
@@ -28,7 +28,7 @@ class DrivesDrainHandlerSpec extends FlatSpec with SpecTools {
 
   "The DrivesDrainHandler" should "handle POST" in
     served { case (port, controller) =>
-      (controller.drain _) .expects (Seq.empty) .returning (supply())
+      (controller.drain _) .expects (Seq.empty) .returning (supply (()))
       given
         .port (port)
         .body ("[]")

--- a/twitter-server/test/com/treode/twitter/server/handler/SpecTools.scala
+++ b/twitter-server/test/com/treode/twitter/server/handler/SpecTools.scala
@@ -25,7 +25,7 @@ import com.treode.twitter.finagle.http.filter._
 import com.twitter.finagle.{Http, Service}
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle.http.filter.ExceptionFilter
-import org.hamcrest.{Description, Matcher, Matchers, TypeSafeMatcher}, Matchers._
+import org.hamcrest.{Description, Matcher, Matchers, TypeSafeMatcher}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.Suite
 


### PR DESCRIPTION
Twitter Server 1.9.0 and Finagle 6.24 can be compiled with Scala 2.11, finally. This upgrades the Finagle and Unfiltered examples.

Finatra remains stuck on Finagle 6.22; it is incompatible with Finagle 6.24. Finatra plans no support for any of this until Finatra 2.0. Rather than hold everything else back, I've cut Finatra from the build.

Much of Spark now compiles against 2.11, but the REPL remains stuck on 2.10, so the Movies example is still on 2.10.