### PR TITLE
Fix StubFile align calculation and related tests.

### DIFF
--- a/async/stub/com/treode/async/io/stubs/StubFile.scala
+++ b/async/stub/com/treode/async/io/stubs/StubFile.scala
@@ -123,8 +123,8 @@ class StubFile private (
 object StubFile {
 
   def apply (data: Array [Byte], align: Int) (implicit scheduler: Scheduler): StubFile = {
-    require (align > 0, "Alignment must more than 0 bits")
-    new StubFile (data, align-1)
+    require (align >= 0, "Alignment must be non-negative")
+    new StubFile (data, (1 << align) - 1)
   }
 
   def apply (size: Int, align: Int) (implicit scheduler: Scheduler): StubFile =

--- a/async/test/com/treode/async/io/FileSpec.scala
+++ b/async/test/com/treode/async/io/FileSpec.scala
@@ -237,7 +237,7 @@ class FileSpec extends FlatSpec {
 
   "File.deframe" should "read from Pickler.frame" in {
     implicit val scheduler = StubScheduler.random()
-    val file = StubFile (1 << 12, 1)
+    val file = StubFile (1 << 12, 0)
     val pickler = Picklers.seq (Picklers.int)
     val out = Seq.fill (23) (Random.nextInt)
     val buffer = PagedBuffer (12)
@@ -251,7 +251,7 @@ class FileSpec extends FlatSpec {
 
   it should "read from Pickler.frame with hashing" in {
     implicit val scheduler = StubScheduler.random()
-    val file = StubFile (1 << 12, 1)
+    val file = StubFile (1 << 12, 0)
     val pickler = Picklers.seq (Picklers.int)
     val out = Seq.fill (23) (Random.nextInt)
     val buffer = PagedBuffer (12)
@@ -265,7 +265,7 @@ class FileSpec extends FlatSpec {
 
   it should "raise an error when the hash check fails" in {
     implicit val scheduler = StubScheduler.random()
-    val file = StubFile (1 << 12, 1)
+    val file = StubFile (1 << 12, 0)
     val pickler = Picklers.seq (Picklers.int)
     val out = Seq.fill (23) (Random.nextInt)
     val buffer = PagedBuffer (12)

--- a/disk/src/com/treode/disk/PageLedger.scala
+++ b/disk/src/com/treode/disk/PageLedger.scala
@@ -188,7 +188,6 @@ private object PageLedger {
 
   def read (file: File, geom: DriveGeometry, pos: Long): Async [PageLedger] =
     guard {
-      // TODO: fix read alignment issues in StubFile
       val buf = PagedBuffer (math.max (12, geom.blockBits))
       for (_ <- file.deframe (checksum, buf, pos, geom.blockBits))
         yield Zipped.pickler.unpickle (buf) .unzip


### PR DESCRIPTION
As discussed in https://forum.treode.com/t/alignment-mask-in-stubfile-is-computed-incorrectly/38.