### PR TITLE
Allocate the current page segment after writing the superblock.

### DIFF
--- a/disk/src/com/treode/disk/DiskDrive.scala
+++ b/disk/src/com/treode/disk/DiskDrive.scala
@@ -397,7 +397,6 @@ private object DiskDrive {
       val logSeg = alloc.alloc (geom, config)
       val logSegs = new ArrayDeque [Int]
       logSegs.add (logSeg.num)
-      val pageSeg = alloc.alloc (geom, config)
 
       val superb = SuperBlock (id, boot, geom, false, alloc.free, logSeg.base)
 
@@ -407,6 +406,7 @@ private object DiskDrive {
             SuperBlock.clear (boot.gen + 1, file),
             RecordHeader.init (file, geom, logSeg.base))
       } yield {
+        val pageSeg = alloc.alloc (geom, config)
         new DiskDrive (id, path, file, geom, alloc, kit, logBuf, false, logSegs, logSeg.base,
             logSeg.base, logSeg.limit, pageSeg, pageSeg.limit, new PageLedger, true)
        }}


### PR DESCRIPTION
The superblock records the filled page segments; it must not record the current page segment. Doing so causes the compactor to try to sweep it, and that leads to bad things.