### PR TITLE
Fence stub globals into special object.

### DIFF
--- a/async/stub/com/treode/async/stubs/StubGlobals.scala
+++ b/async/stub/com/treode/async/stubs/StubGlobals.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 Treode, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.treode.async.stubs
+
+import java.util.concurrent.{Executors, ScheduledExecutorService}
+import scala.concurrent.ExecutionContext
+
+object StubGlobals {
+
+  /** A default ScheduledExecutorService. */
+  val executor: ScheduledExecutorService =
+    Executors.newScheduledThreadPool (Runtime.getRuntime.availableProcessors)
+
+  /** A default StubScheduler that uses the default executor. */
+  implicit val scheduler: StubScheduler =
+    StubScheduler.wrapped (executor)
+
+  /** A default ExecutionContext that uses the default executor. */
+  implicit val executionContext: ExecutionContext =
+    ExecutionContext.fromExecutorService (executor)
+}

--- a/async/stub/com/treode/async/stubs/StubScheduler.scala
+++ b/async/stub/com/treode/async/stubs/StubScheduler.scala
@@ -16,8 +16,7 @@
 
 package com.treode.async.stubs
 
-import java.util.concurrent.{Executors, ScheduledExecutorService}
-import scala.concurrent.ExecutionContext
+import java.util.concurrent.ScheduledExecutorService
 import scala.util.Random
 
 import com.treode.async.Scheduler
@@ -58,16 +57,4 @@ object StubScheduler {
     */
   def wrapped (executor: ScheduledExecutorService): StubScheduler =
     new StubExecutorAdaptor (executor)
-
-  /** A default ScheduledExecutorService. */
-  val executor: ScheduledExecutorService =
-    Executors.newScheduledThreadPool (Runtime.getRuntime.availableProcessors)
-
-  /** A default StubScheduler that uses the default executor. */
-  implicit val scheduler: StubScheduler =
-    StubScheduler.wrapped (executor)
-
-  /** A default ExecutionContext that uses the default executor. */
-  implicit val executionContext: ExecutionContext =
-    ExecutionContext.fromExecutorService (executor)
 }

--- a/async/test/com/treode/async/implicits/RichScalaFutureSpec.scala
+++ b/async/test/com/treode/async/implicits/RichScalaFutureSpec.scala
@@ -18,7 +18,7 @@ package com.treode.async.implicits
 
 import scala.concurrent.Future
 
-import com.treode.async.stubs.StubScheduler, StubScheduler.executionContext
+import com.treode.async.stubs.{StubGlobals, StubScheduler}, StubGlobals.executionContext
 import org.scalatest.FlatSpec
 
 class RichScalaFutureSpec extends FlatSpec {

--- a/cluster/test/com/treode/cluster/ClusterLiveSpec.scala
+++ b/cluster/test/com/treode/cluster/ClusterLiveSpec.scala
@@ -21,15 +21,12 @@ import java.util.concurrent.TimeoutException
 import scala.util.Random
 import scala.language.postfixOps
 
-import com.treode.async.{Async, Backoff, Callback, Fiber, Scheduler}
+import com.treode.async.{Async, Backoff, Callback, Fiber, Scheduler}, 
+  Async.{async, supply}, Callback.{ignore => disregard}
 import com.treode.async.implicits._
-import com.treode.async.stubs.{AsyncChecks, StubScheduler}
+import com.treode.async.stubs.{AsyncChecks, StubGlobals, StubScheduler}, StubGlobals.scheduler
 import com.treode.pickle.Picklers
 import org.scalatest.FlatSpec
-
-import Async.{async, supply}
-import Callback.{ignore => disregard}
-import StubScheduler.scheduler
 
 class ClusterLiveSpec extends FlatSpec {
 

--- a/disk/test/com/treode/disk/DiskSystemSpec.scala
+++ b/disk/test/com/treode/disk/DiskSystemSpec.scala
@@ -21,7 +21,7 @@ import scala.util.Random
 
 import com.treode.async.Async
 import com.treode.async.io.stubs.StubFile
-import com.treode.async.stubs.StubScheduler
+import com.treode.async.stubs.{StubGlobals, StubScheduler}
 import com.treode.async.stubs.implicits._
 import com.treode.disk.stubs.CrashChecks
 import com.treode.tags.{Intensive, Periodic}
@@ -264,7 +264,7 @@ class DiskSystemSpec extends FreeSpec with CrashChecks {
       }}
 
     "when multithreaded" taggedAs (Intensive, Periodic) in {
-      import StubScheduler.scheduler
+      import StubGlobals.scheduler
 
       implicit val config = DiskTestConfig (
           maximumRecordBytes = 1<<9,

--- a/disk/test/com/treode/disk/LogSpec.scala
+++ b/disk/test/com/treode/disk/LogSpec.scala
@@ -19,17 +19,16 @@ package com.treode.disk
 import java.util.logging.{Level, Logger}
 import scala.util.Random
 
-import com.treode.async._
+import com.treode.async._, Async.{async, latch}
 import com.treode.async.implicits._
 import com.treode.async.io.stubs.StubFile
-import com.treode.async.stubs.{AsyncCaptor, StubScheduler}
+import com.treode.async.stubs.{AsyncCaptor, StubScheduler, StubGlobals}
 import com.treode.async.stubs.implicits._
 import com.treode.disk.stubs.CrashChecks
 import com.treode.pickle.{InvalidTagException, Picklers}
 import com.treode.tags.Periodic
 import org.scalatest.FlatSpec
-
-import Async.{async, latch}
+ 
 import DiskTestTools._
 
 class LogSpec extends FlatSpec with CrashChecks {
@@ -244,10 +243,10 @@ class LogSpec extends FlatSpec with CrashChecks {
 
       // Restart with a low threshold, replays should trigger a checkpoint.
       {
+        implicit val scheduler = StubScheduler.random()
         implicit val config = DiskTestConfig (checkpointEntries = 1)
         val captor = AsyncCaptor [Unit]
 
-        implicit val scheduler = StubScheduler.random()
         file = StubFile (file.data, geom.blockBits)
         implicit val recovery = Disk.recover()
         records.str.replay (_ => ())

--- a/disk/test/com/treode/disk/PageSpec.scala
+++ b/disk/test/com/treode/disk/PageSpec.scala
@@ -209,12 +209,11 @@ class PageSpec extends FreeSpec {
 
       // Restart with a low threshold, allocations should trigger a compaction.
       {
-        println ("restart")
+        implicit val random = new Random (0)
+        implicit val scheduler = StubScheduler.random (random)
         implicit val config = DiskTestConfig (cleaningFrequency = 1)
         val captor = AsyncCaptor [Set [Int]]
 
-        implicit val random = new Random (0)
-        implicit val scheduler = StubScheduler.random (random)
         file = StubFile (file.data, geom.blockBits)
         val recovery = Disk.recover()
         implicit val launch = recovery.reattachAndWait (("a", file)) .expectPass()

--- a/examples/finagle/src/test/scala/example/ResourceSpec.scala
+++ b/examples/finagle/src/test/scala/example/ResourceSpec.scala
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.jayway.restassured.RestAssured.given
 import com.jayway.restassured.response.{Response => RestAssuredResponse}
 import com.jayway.restassured.specification.ResponseSpecification
-import com.treode.async.stubs.StubScheduler, StubScheduler.scheduler
+import com.treode.async.stubs.{StubGlobals, StubScheduler}, StubGlobals.scheduler
 import com.treode.store.{Bytes, Cell, TxClock, TxId, WriteOp}, WriteOp._
 import com.treode.store.stubs.StubStore
 import com.treode.twitter.finagle.http.filter._

--- a/examples/movies/server/test/movies/SpecTools.scala
+++ b/examples/movies/server/test/movies/SpecTools.scala
@@ -22,7 +22,7 @@ import scala.util.Random
 import com.fasterxml.jackson.databind.JsonNode
 import com.jayway.restassured.response.{Response => RestAssuredResponse}
 import com.jayway.restassured.specification.ResponseSpecification
-import com.treode.async.stubs.StubScheduler, StubScheduler.scheduler
+import com.treode.async.stubs.{StubGlobals, StubScheduler}, StubGlobals.scheduler
 import com.treode.async.stubs.implicits._
 import com.treode.store.{Bytes, Cell, TxClock, TxId}
 import com.treode.store.stubs.StubStore

--- a/examples/unfiltered/src/test/scala/example/ResourceSpec.scala
+++ b/examples/unfiltered/src/test/scala/example/ResourceSpec.scala
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.jayway.restassured.RestAssured.given
 import com.jayway.restassured.response.{Response => RestAssuredResponse}
 import com.jayway.restassured.specification.ResponseSpecification
-import com.treode.async.stubs.StubScheduler, StubScheduler.{scheduler, executionContext}
+import com.treode.async.stubs.{StubGlobals, StubScheduler}, StubGlobals._
 import com.treode.store.{Bytes, Cell, TxClock, TxId, WriteOp}, WriteOp._
 import com.treode.store.stubs.StubStore
 import org.hamcrest.{Description, Matcher, Matchers, TypeSafeMatcher}, Matchers._

--- a/store/test/com/treode/store/atomic/AtomicSpec.scala
+++ b/store/test/com/treode/store/atomic/AtomicSpec.scala
@@ -19,7 +19,7 @@ package com.treode.store.atomic
 import java.util.concurrent.Executors
 import scala.util.Random
 
-import com.treode.async.stubs.{AsyncChecks, CallbackCaptor, StubScheduler}
+import com.treode.async.stubs.{AsyncChecks, CallbackCaptor, StubGlobals, StubScheduler}
 import com.treode.async.stubs.implicits._
 import com.treode.cluster.stubs.StubNetwork
 import com.treode.store._
@@ -57,7 +57,7 @@ class AtomicSpec extends FreeSpec with StoreBehaviors with AsyncChecks with Time
       }}
 
     "conserve money during account transfers (multithreaded)" taggedAs (Intensive, Periodic) in {
-      import StubScheduler.scheduler
+      import StubGlobals.scheduler
       implicit val random = Random
       implicit val network = StubNetwork (random)
       implicit val store = newStore()

--- a/store/test/com/treode/store/stubs/StubStoreSpec.scala
+++ b/store/test/com/treode/store/stubs/StubStoreSpec.scala
@@ -20,7 +20,7 @@ import java.util.concurrent.Executors
 import scala.util.Random
 
 import com.treode.async.{Async, Scheduler}
-import com.treode.async.stubs.{AsyncChecks, StubScheduler}
+import com.treode.async.stubs.{AsyncChecks, StubGlobals, StubScheduler}
 import com.treode.tags.{Intensive, Periodic}
 import com.treode.store._
 import org.scalatest.FreeSpec
@@ -35,7 +35,7 @@ class StubStoreSpec extends FreeSpec with AsyncChecks with StoreBehaviors {
     }
 
     "conserve money during account transfers (multithreaded)" taggedAs (Intensive, Periodic) in {
-      import StubScheduler.scheduler
+      import StubGlobals.scheduler
       implicit val random = Random
       implicit val store = new StubStore () (scheduler)
       testAccountTransfers (500)


### PR DESCRIPTION
When the compiler needed an implicit StubScheduler, and it could not find one in scope, it happily grabbed the global one. It would have saved us much debugging time to get an error instead. This hides the globals in a differently named class so that one must make them available explicitly.