### PR TITLE
Made changes to Dispatch.scala to eliminate the engage variable. Rewrote...

### DIFF
--- a/disk/src/com/treode/disk/DiskDrive.scala
+++ b/disk/src/com/treode/disk/DiskDrive.scala
@@ -273,7 +273,7 @@ private class DiskDrive (
     fiber.execute {
 
       val (accepts, rejects, realloc) = splitRecords (entries)
-      logmp.replace (rejects)
+      logmp.send (rejects)
       val (callbacks, length) = writeRecords (logBuf, batch, accepts)
       val cb = fanout (callbacks)
       checkpointer.tally (length, accepts.size)
@@ -349,7 +349,7 @@ private class DiskDrive (
     fiber.execute {
 
       val (accepts, rejects, realloc) = splitPages (pages)
-      pagemp.replace (rejects)
+      pagemp.send (rejects)
       val (buffer, callbacks, ledger) = writePages (accepts)
       val pos = pageHead - buffer.readableBytes
       assert (pos >= pageSeg.base + blockBytes)

--- a/disk/src/com/treode/disk/Multiplexer.scala
+++ b/disk/src/com/treode/disk/Multiplexer.scala
@@ -96,7 +96,7 @@ private class Multiplexer [M] (dispatcher: Dispatcher [M]) (
     case _ =>
       assert (enrolled)
       enrolled = false
-      dispatcher.replace (messages)
+      dispatcher.send (messages)
   }
 
   private val dispatch = (_dispatch _)
@@ -123,12 +123,12 @@ private class Multiplexer [M] (dispatcher: Dispatcher [M]) (
       scheduler.pass (fanout (cbs), ())
   }
 
-  def replace (rejects: UnrolledBuffer [M]): Unit = execute {
+  def send (rejects: UnrolledBuffer [M]): Unit = execute {
     case _ if exclusive =>
       messages = rejects.concat (messages)
     case _ =>
       assert (!enrolled)
-      dispatcher.replace (rejects)
+      dispatcher.send (rejects)
   }
 
   def pause(): Async [Unit] = async {

--- a/disk/stub/com/treode/disk/stubs/StubDisk.scala
+++ b/disk/stub/com/treode/disk/stubs/StubDisk.scala
@@ -49,7 +49,7 @@ private class StubDisk (
   }
 
   def receiver (batch: Long, records: UnrolledBuffer [(StubRecord, Callback [Unit])]) {
-    logd.replace (new UnrolledBuffer)
+    logd.send (new UnrolledBuffer [(StubRecord, Callback [Unit])])
     val cb = fanout (records .map (_._2))
     disk.log (records .map (_._1) .toSeq) .run { v =>
       logd.receive (receiver _)

--- a/disk/test/com/treode/disk/DiskTestTools.scala
+++ b/disk/test/com/treode/disk/DiskTestTools.scala
@@ -26,6 +26,7 @@ import com.treode.async.Async
 import com.treode.async.io.stubs.StubFile
 import com.treode.async.stubs.{CallbackCaptor, StubScheduler}
 import com.treode.async.stubs.implicits._
+import com.treode.async.implicits._
 import org.scalatest.Assertions
 
 import Assertions.assertResult
@@ -131,7 +132,7 @@ private object DiskTestTools {
     private def tickle [M] (dispatcher: Dispatcher [M]) (
         implicit tag: ClassTag [M], scheduler: StubScheduler): Int = {
       while (!dispatcher.receivers.isEmpty)
-        dispatcher.receivers.remove () (0L, new UnrolledBuffer [M])
+        dispatcher.receivers.remove ().pass((0L, new UnrolledBuffer [M]) )
       scheduler.run()
     }
 

--- a/disk/test/com/treode/disk/DispatcherSpec.scala
+++ b/disk/test/com/treode/disk/DispatcherSpec.scala
@@ -20,9 +20,9 @@ import scala.collection.mutable.UnrolledBuffer
 import scala.util.Random
 
 import com.treode.async.stubs.StubScheduler
+import com.treode.async.stubs.implicits._
 import org.scalatest.FlatSpec
 
-import DispatcherTestTools._
 
 class DispatcherSpec extends FlatSpec {
 
@@ -30,145 +30,62 @@ class DispatcherSpec extends FlatSpec {
     implicit val scheduler = StubScheduler.random()
     val dsp = new Dispatcher [Int] (0)
     dsp.send (1)
-    dsp.expect (1)
-    dsp.replace (list())
-    dsp.expectNone()
-  }
-
-  it should "send multiple messages to a later receiver" in {
-    implicit val scheduler = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
-    dsp.send (1)
-    dsp.send (2)
-    dsp.send (3)
-    dsp.expect (1, 2, 3)
-    dsp.replace (list())
-    dsp.expectNone()
+    val captor = dsp.receive().capture()
+    captor.expectPass( (1, UnrolledBuffer(1) ) )
   }
 
   it should "send one message to an earlier receiver" in {
     implicit val scheduler = StubScheduler.random()
     val dsp = new Dispatcher [Int] (0)
-    val rcpt = dsp.receptor()
+    val captor = dsp.receive().capture()
     dsp.send (1)
-    rcpt.expect (1)
-    dsp.replace (list())
-    dsp.expectNone()
+    captor.expectPass( (1, UnrolledBuffer(1)))
   }
 
-  it should "send multiple messages to an earlier receiver" in {
-    implicit val scheduler = StubScheduler.random()
+  it should "queue several messages to a receiver" in {
+    implicit val schedule = StubScheduler.random()
     val dsp = new Dispatcher [Int] (0)
-    val rcpt1 = dsp.receptor()
-    val rcpt2 = dsp.receptor()
     dsp.send (1)
     dsp.send (2)
     dsp.send (3)
-    rcpt1.expect (1)
-    rcpt2.assertNotInvoked()
-    dsp.replace (list())
-    rcpt2.expect (2, 3)
-    dsp.replace (list())
-    dsp.expectNone()
+    val captor = dsp.receive().capture()
+    captor.expectPass((1, UnrolledBuffer(1,2,3)))
   }
 
-  it should "send multiple messages to a later receiver when disengaged" in {
+  it should "attempt to send multiple messages with only one receiver" in {
+    implicit val schedule = StubScheduler.random()
+    val dsp = new Dispatcher [Int] (0)
+    val captor = dsp.receive().capture()
+    dsp.send (1)
+    dsp.send (2)
+    captor.expectPass((1, UnrolledBuffer(1)))
+  }
+
+  it should "create several receievers, each should receive a single message " in {
     implicit val scheduler = StubScheduler.random()
     val dsp = new Dispatcher [Int] (0)
-    val rcpt1 = dsp.receptor()
+    val captor = dsp.receive().capture()
+    val captor2 = dsp.receive().capture()
     dsp.send (1)
-    val rcpt2 = dsp.receptor()
     dsp.send (2)
     dsp.send (3)
-    rcpt1.expect (1)
-    rcpt2.assertNotInvoked()
-    dsp.replace (list())
-    rcpt2.expect (2, 3)
-    dsp.replace (list())
-    dsp.expectNone()
+    captor.expectPass((1, UnrolledBuffer(1)))
+    captor2.expectPass((2, UnrolledBuffer(2)))
+  
   }
 
-  it should "send rejects to the next receiver" in {
+  it should "have two messages immediately get picked up by receivers, leaving one messaged queued and later received" in {
     implicit val scheduler = StubScheduler.random()
     val dsp = new Dispatcher [Int] (0)
+    val captor = dsp.receive().capture()
+    val captor2 = dsp.receive().capture()
     dsp.send (1)
     dsp.send (2)
-    dsp.expect (1, 2)
-    dsp.replace (list (2))
-    dsp.expect (2)
-    dsp.replace (list())
-  }
-
-  it should "send rejects to the next receiver from earlier" in {
-    implicit val scheduler = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
-    dsp.send (1)
-    dsp.send (2)
-    val rcpt1 = dsp.receptor()
-    val rcpt2 = dsp.receptor()
-    rcpt1.expect (1, 2)
-    rcpt2.assertNotInvoked()
-    dsp.replace (list (2))
-    rcpt2.expect (2)
-    dsp.replace (list())
-  }
-
-  it should "send rejects and queued messages to the next receiver" in {
-    implicit val scheduler = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
-    dsp.send (1)
-    dsp.send (2)
-    val rcpt1 = dsp.receptor()
     dsp.send (3)
-    rcpt1.expect (1, 2)
-    dsp.replace (list (2))
-    scheduler.run()
-    val rcpt2 = dsp.receptor()
-    rcpt2.expect (2, 3)
-    dsp.replace (list())
+    captor.expectPass((1, UnrolledBuffer(1)))
+    captor2.expectPass((2, UnrolledBuffer(2)))
+    val captor3 = dsp.receive().capture()
+    captor3.expectPass((3, UnrolledBuffer(3)))
   }
+}
 
-  it should "send rejects and queued messages to the next receiver from earlier" in {
-    implicit val scheduler = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
-    dsp.send (1)
-    dsp.send (2)
-    val rcpt1 = dsp.receptor()
-    val rcpt2 = dsp.receptor()
-    dsp.send (3)
-    rcpt1.expect (1, 2)
-    rcpt2.assertNotInvoked()
-    dsp.replace (list (2))
-    rcpt2.expect (2, 3)
-    dsp.replace (list())
-  }
-
-  it should "recycle rejects until accepted" in {
-
-    implicit val scheduler = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
-
-    var received = Set.empty [Int]
-
-    /* Accept upto 5 messages m where (m % n == i).
-     * Ensure m was not already accepted.
-     */
-    def receive (n: Int, i: Int) (num: Long, msgs: UnrolledBuffer [Int]) {
-      assert (!(msgs exists (received contains _)))
-      val (accepts, rejects) = msgs.partition (_ % n == i)
-      dsp.replace ((accepts drop 5) ++ rejects)
-      received ++= accepts take 5
-      dsp.receive (receive (n, i))
-    }
-
-    dsp.receive (receive (3, 0))
-    dsp.receive (receive (3, 1))
-    dsp.receive (receive (3, 2))
-
-    val count = 100
-    for (i <- 0 until count)
-      dsp.send (i)
-    scheduler.run()
-
-    assertResult ((0 until count).toSet) (received)
-  }}

--- a/disk/test/com/treode/disk/MultiplexerSpec.scala
+++ b/disk/test/com/treode/disk/MultiplexerSpec.scala
@@ -22,7 +22,7 @@ import com.treode.async.stubs.StubScheduler
 import com.treode.async.stubs.implicits._
 import org.scalatest.FlatSpec
 
-import DispatcherTestTools._
+import MultiplexerTestTools._
 
 class MultiplexerSpec extends FlatSpec {
 
@@ -32,7 +32,6 @@ class MultiplexerSpec extends FlatSpec {
     val mplx = new Multiplexer (dsp)
     dsp.send (1)
     mplx.expect (1)
-    mplx.replace (list())
     mplx.expectNone()
   }
 
@@ -43,9 +42,8 @@ class MultiplexerSpec extends FlatSpec {
     dsp.send (1)
     dsp.send (2)
     mplx.expect (1, 2)
-    mplx.replace (list (2))
+    mplx.send (list (2))
     dsp.expect (2)
-    dsp.replace (list())
     mplx.expectNone()
   }
 
@@ -55,7 +53,6 @@ class MultiplexerSpec extends FlatSpec {
     val mplx = new Multiplexer (dsp)
     mplx.send (2)
     mplx.expect (2)
-    mplx.replace (list())
     mplx.expectNone()
   }
 
@@ -68,9 +65,8 @@ class MultiplexerSpec extends FlatSpec {
     scheduler.run()
     mplx.send (2)
     rcpt2.expect (2)
-    mplx.replace (list (2))
+    mplx.send (list (2))
     mplx.expect (2)
-    mplx.replace (list())
     rcpt1.expectNone()
   }
 
@@ -81,9 +77,8 @@ class MultiplexerSpec extends FlatSpec {
     val mplx = new Multiplexer (dsp)
     mplx.send (2)
     mplx.expect (2)
-    mplx.replace (list (2))
+    mplx.send (list (2))
     mplx.expect (2)
-    mplx.replace (list())
     rcpt1.expectNone()
   }
 
@@ -130,7 +125,7 @@ class MultiplexerSpec extends FlatSpec {
       assert (!(msgs exists (received contains _)))
       assert (msgs forall (m => ((m & 0xF) == 0 || (m & 0xF) == i)))
       val (accepts, rejects) = msgs.partition (m => (m & 0xF0) == (i << 4))
-      mplx.replace ((accepts drop 5) ++ rejects)
+      mplx.send ((accepts drop 5) ++ rejects)
       received ++= accepts take 5
       mplx.receive (receive (mplx, i))
     }

--- a/disk/test/com/treode/disk/MultiplexerTestTools.scala
+++ b/disk/test/com/treode/disk/MultiplexerTestTools.scala
@@ -24,7 +24,7 @@ import org.scalatest.Assertions
 
 import Assertions.{assertResult, fail}
 
-object DispatcherTestTools {
+object MultiplexerTestTools {
 
   def list [M] (messages: M*) (implicit mtag: ClassTag [M]): UnrolledBuffer [M] =
     UnrolledBuffer [M] (messages: _*)


### PR DESCRIPTION
... several test in DispatcherSpec to accomodate changes. Behavior does not seem to match expected behavior.

fixed up the reject convention in dispatch modified convention

Modified tests, made shorter and more relevant to new method of receiving messages

made old recieve asynchrnous

Modified tests for new asynchronous method of receiving

Removed the dependency of dispatcherSpec on the DispatcherSpecTestTools and instead renamed file to MultiplexerTestTools