### PR TITLE
More permissive expectations.

### DIFF
--- a/async/stub/com/treode/async/stubs/CallbackCaptor.scala
+++ b/async/stub/com/treode/async/stubs/CallbackCaptor.scala
@@ -21,10 +21,10 @@ import scala.util.{Failure, Success, Try}
 import org.scalatest.Assertions
 
 /** Capture the result of an asynchronous call so you may test for success or failure later. */
-class CallbackCaptor [T] private extends (Try [T] => Unit) with Assertions {
+class CallbackCaptor [A] private extends (Try [A] => Unit) with Assertions {
 
   private var _invokation: Array [StackTraceElement] = null
-  private var _v: T = null.asInstanceOf [T]
+  private var _v: A = null.asInstanceOf [A]
   private var _t: Throwable = null
 
   private def invoked() {
@@ -37,7 +37,7 @@ class CallbackCaptor [T] private extends (Try [T] => Unit) with Assertions {
       fail ("Callback was already invoked.")
     }}
 
-  def apply (v: Try [T]): Unit = synchronized {
+  def apply (v: Try [A]): Unit = synchronized {
     invoked()
     v match {
       case Success (v) => _v = v
@@ -74,7 +74,7 @@ class CallbackCaptor [T] private extends (Try [T] => Unit) with Assertions {
   }
 
   /** Assert the callback was invoked with [[scala.util.Success Success]] and return the result. */
-  def assertPassed(): T = synchronized {
+  def assertPassed(): A = synchronized {
     assertInvoked()
     if (_t != null)
       throw _t
@@ -83,12 +83,12 @@ class CallbackCaptor [T] private extends (Try [T] => Unit) with Assertions {
 
   /** Assert the callback was invoked with [[scala.util.Success Success]] and assert the result was
     * the expected value. */
-  def assertPassed (expected: T): Unit =
+  def assertPassed (expected: A): Unit =
     assertResult (expected) (assertPassed)
 
   /** Assert the callback was invoked with [[scala.util.Success Success]] and assert the result was
     * the expected [[scala.collection.Seq Seq]]. */
-  def assertSeq [S] (xs: S*) (implicit w: T <:< Seq [S]): Unit =
+  def assertSeq [B] (xs: B*) (implicit w: A <:< Seq [B]): Unit =
     assertResult (xs) (assertPassed)
 
 
@@ -115,7 +115,7 @@ class CallbackCaptor [T] private extends (Try [T] => Unit) with Assertions {
   /** Run until the callback has been invoked, then assert that it yielded
     * [[scala.util.Success Success]] and return the result.
     */
-  def expectPass () (implicit s: StubScheduler): T = {
+  def expectPass () (implicit s: StubScheduler): A = {
     s.run (timers = !wasInvoked)
     assertPassed
   }
@@ -123,7 +123,7 @@ class CallbackCaptor [T] private extends (Try [T] => Unit) with Assertions {
   /** Run until the callback has been invoked, then assert that it yielded
     * [[scala.util.Success Success]] and check that the result is as expected.
     */
-  def expectPass (expected: T) (implicit s: StubScheduler) {
+  def expectPass (expected: Any) (implicit s: StubScheduler) {
     s.run (timers = !wasInvoked)
     assertResult (expected) (assertPassed)
   }
@@ -132,7 +132,7 @@ class CallbackCaptor [T] private extends (Try [T] => Unit) with Assertions {
     * [[scala.util.Success Success]] and assert that the result was the expect
     * [[scala.collection.Seq Seq]].
     */
-  def expectSeq [S] (xs: S*) (implicit s: StubScheduler, w: T <:< Seq [S]) {
+  def expectSeq [B] (xs: B*) (implicit s: StubScheduler, w: A <:< Seq [B]) {
     s.run (timers = !wasInvoked)
     assertResult (xs) (assertPassed)
   }
@@ -156,5 +156,5 @@ class CallbackCaptor [T] private extends (Try [T] => Unit) with Assertions {
 
 object CallbackCaptor {
 
-  def apply [T] = new CallbackCaptor [T]
+  def apply [A] = new CallbackCaptor [A]
 }

--- a/async/stub/com/treode/async/stubs/implicits/package.scala
+++ b/async/stub/com/treode/async/stubs/implicits/package.scala
@@ -44,7 +44,7 @@ package object implicits {
     /** Run until the asynchronous operation completes, then assert that it yielded
       * [[scala.util.Success Failure]] and assert that the result is as expected.
       */
-    def expectPass (expected: A) (implicit scheduler: StubScheduler): Unit =
+    def expectPass (expected: Any) (implicit scheduler: StubScheduler): Unit =
       assertResult (expected) (expectPass())
 
     /** Run until the asynchronous operation completes, then assert that it yielded

--- a/disk/test/com/treode/disk/DispatcherSpec.scala
+++ b/disk/test/com/treode/disk/DispatcherSpec.scala
@@ -16,7 +16,6 @@
 
 package com.treode.disk
 
-import scala.collection.mutable.UnrolledBuffer
 import scala.util.Random
 
 import com.treode.async.stubs.StubScheduler
@@ -31,7 +30,7 @@ class DispatcherSpec extends FlatSpec {
     val dsp = new Dispatcher [Int] (0)
     dsp.send (1)
     val captor = dsp.receive().capture()
-    captor.expectPass ((1, UnrolledBuffer (1)))
+    captor.expectPass ((1, Seq (1)))
   }
 
   it should "send one message to an earlier receiver" in {
@@ -39,7 +38,7 @@ class DispatcherSpec extends FlatSpec {
     val dsp = new Dispatcher [Int] (0)
     val captor = dsp.receive().capture()
     dsp.send (1)
-    captor.expectPass ((1, UnrolledBuffer (1)))
+    captor.expectPass ((1, Seq (1)))
   }
 
   it should "queue several messages to a receiver" in {
@@ -49,7 +48,7 @@ class DispatcherSpec extends FlatSpec {
     dsp.send (2)
     dsp.send (3)
     val captor = dsp.receive().capture()
-    captor.expectPass ((1, UnrolledBuffer (1,2,3)))
+    captor.expectPass ((1, Seq (1,2,3)))
   }
 
   it should "attempt to send multiple messages with only one receiver" in {
@@ -58,7 +57,7 @@ class DispatcherSpec extends FlatSpec {
     val captor = dsp.receive().capture()
     dsp.send (1)
     dsp.send (2)
-    captor.expectPass ((1, UnrolledBuffer(1)))
+    captor.expectPass ((1, Seq(1)))
   }
 
   it should "create several receievers, each should receive a single message " in {
@@ -69,8 +68,8 @@ class DispatcherSpec extends FlatSpec {
     dsp.send (1)
     dsp.send (2)
     dsp.send (3)
-    captor.expectPass ((1, UnrolledBuffer(1)))
-    captor2.expectPass ((2, UnrolledBuffer(2)))
+    captor.expectPass ((1, Seq (1)))
+    captor2.expectPass ((2, Seq (2)))
   
   }
 
@@ -82,8 +81,8 @@ class DispatcherSpec extends FlatSpec {
     dsp.send (1)
     dsp.send (2)
     dsp.send (3)
-    captor.expectPass ((1, UnrolledBuffer(1)))
-    captor2.expectPass ((2, UnrolledBuffer(2)))
+    captor.expectPass ((1, Seq (1)))
+    captor2.expectPass ((2, Seq (2)))
     val captor3 = dsp.receive().capture()
-    captor3.expectPass ((3, UnrolledBuffer(3)))
+    captor3.expectPass ((3, Seq (3)))
   }}


### PR DESCRIPTION
Suppose we have

    def f(): Async [Seq [Int]]
    def g(): Async [List [Int]]

Before this change, one was forced to use the same type as the async. The following lines would raise an error:

    f().expectPass (List (1))
    g().expectPass (Seq (1))

These are reasonable things to write in a test. With this change, they are allowed.