### PR TITLE
Separate forAllSeeds from forAllRandoms.

### DIFF
--- a/async/stub/com/treode/async/stubs/AsyncChecks.scala
+++ b/async/stub/com/treode/async/stubs/AsyncChecks.scala
@@ -33,21 +33,27 @@ trait AsyncChecks {
     if (envseeds == null) 1 else Integer.parseInt(envseeds)
   }
 
-  /** Run the test with a PRNG seeded by `seed`. */
-  def forSeed (seed: Long) (test: Random => Any) {
+  /** Run the test with `seed`; add `seed` to the test info on failure. */
+  def forSeed (seed: Long) (test: Long => Any) {
     try {
-      val random = new Random (seed)
-      test (random)
+      test (seed)
     } catch {
       case t: Throwable =>
         info (s"Test failed; seed = ${seed}L")
         throw t
     }}
 
+  /** Run a test many times, each time with a different seed. Use `NSEEDS` from the environment to
+    * determine how many times, or defaults to 1.
+    */
+  def forAllSeeds (test: Long => Any) {
+    for (_ <- 0 until nseeds)
+      forSeed (Random.nextLong) (test)
+  }
+
   /** Run a psuedo-random test many times, each time with a PRNG seeded differently. Use `NSEEDS`
     * from the environment to determine how many times, or defaults to 1.
     */
-  def forAllSeeds (test: Random => Any) {
-    for (_ <- 0 until nseeds)
-      forSeed (Random.nextLong) (test)
-  }}
+  def forAllRandoms (test: Random => Any): Unit =
+    forAllSeeds (seed => test (new Random (seed)))
+}

--- a/async/stub/com/treode/async/stubs/package.scala
+++ b/async/stub/com/treode/async/stubs/package.scala
@@ -39,11 +39,11 @@ package com.treode.async
   *
   *   "It" should "work" in {
   *
-  *     // The forAllSeeds method runs a test many times, each time with a
+  *     // The forAllRandoms method runs a test many times, each time with a
   *     // Random that has been seeded differently.  If the test throws an
-  *     // error, forAllSeeds will inform you of which seed trigged the
+  *     // error, forAllRandoms will inform you of which seed trigged the
   *     // problem.
-  *     forAllSeeds { random =>
+  *     forAllRandoms { random =>
   *       implicit val scheduler = StubScheduler.random (random)
   *       implicit val latch = new CountDownLatch (2)
   *
@@ -51,14 +51,14 @@ package com.treode.async
   *       val cb = latch.await().capture()
   *
   *       // The decrement method uses fiber.execute which schedules the task,
-  *       // but the StubScheduler does not run it until its runTasks method
-  *       // is called.
+  *       // but the StubScheduler does not run it until its runTasks method is
+  *       // called.
   *       latch.decrement()
   *       latch.decrement()
   *
-  *       // The passed method on the CallbackCaptor runs all current and
-  *       // added tasks; when none remain it checks that the callback was
-  *       // invoked with Success.
+  *       // The passed method on the CallbackCaptor runs all current and added
+  *       // tasks; when none remain it checks that the callback was invoked
+  *       // with Success.
   *       cb.passed
   *     } } }
   * }}}

--- a/async/test/com/treode/async/MergeIteratorSpec.scala
+++ b/async/test/com/treode/async/MergeIteratorSpec.scala
@@ -102,7 +102,7 @@ class MergeIteratorSpec extends FreeSpec with AsyncChecks {
     }
 
     "work with varying inputs" taggedAs (Periodic) in {
-      forAllSeeds { implicit random =>
+      forAllRandoms { implicit random =>
         val inputs =
           // upto 7 inputs
           for (_ <- 0 until random.nextInt (8)) yield {

--- a/cluster/test/com/treode/cluster/ScuttlebuttSpec.scala
+++ b/cluster/test/com/treode/cluster/ScuttlebuttSpec.scala
@@ -271,11 +271,11 @@ class ScuttlebuttProperties extends PropSpec with AsyncChecks {
   }
 
   property ("Scuttlebutt should spread rumors") {
-    forAllSeeds { implicit random =>
+    forAllRandoms { implicit random =>
       checkUnity (0.0) (random)
     }}
 
   property ("Scuttlebutt should spread rumors with a flakey network") {
-    forAllSeeds { random =>
+    forAllRandoms { random =>
       checkUnity (0.1) (random)
     }}}

--- a/disk/test/com/treode/disk/DiskSystemSpec.scala
+++ b/disk/test/com/treode/disk/DiskSystemSpec.scala
@@ -239,7 +239,7 @@ class DiskSystemSpec extends FreeSpec with CrashChecks {
   "The logger should write more data than disk" - {
 
     "when randomly scheduled" taggedAs (Intensive, Periodic) in {
-      forAllSeeds { implicit random =>
+      forAllRandoms { implicit random =>
 
         implicit val config = DiskTestConfig (
             maximumRecordBytes = 1<<9,
@@ -482,7 +482,7 @@ class DiskSystemSpec extends FreeSpec with CrashChecks {
         }}}
 
     "more data than disk" taggedAs (Intensive, Periodic) in {
-      forAllSeeds { implicit random =>
+      forAllRandoms { implicit random =>
 
         implicit val config = DiskTestConfig (
             maximumRecordBytes = 1<<9,

--- a/disk/test/com/treode/disk/LogSpec.scala
+++ b/disk/test/com/treode/disk/LogSpec.scala
@@ -28,7 +28,7 @@ import com.treode.disk.stubs.CrashChecks
 import com.treode.pickle.{InvalidTagException, Picklers}
 import com.treode.tags.Periodic
 import org.scalatest.FlatSpec
- 
+
 import DiskTestTools._
 
 class LogSpec extends FlatSpec with CrashChecks {
@@ -196,7 +196,7 @@ class LogSpec extends FlatSpec with CrashChecks {
 
 
   it should "run one checkpoint at a time" taggedAs (Periodic) in {
-    forAllSeeds { implicit random =>
+    forAllRandoms { implicit random =>
 
       implicit val scheduler = StubScheduler.random (random)
       val file = StubFile (1<<20, geom.blockBits)
@@ -226,7 +226,7 @@ class LogSpec extends FlatSpec with CrashChecks {
     }}
 
   it should "restart a checkpoint after a crash" taggedAs (Periodic) in {
-    forAllSeeds { implicit random =>
+    forAllRandoms { implicit random =>
 
       var file: StubFile = null
 

--- a/store/test/com/treode/store/atomic/AtomicSpec.scala
+++ b/store/test/com/treode/store/atomic/AtomicSpec.scala
@@ -50,7 +50,7 @@ class AtomicSpec extends FreeSpec with StoreBehaviors with AsyncChecks with Time
     }
 
     "conserve money during account transfers" taggedAs (Intensive, Periodic) in {
-      forAllSeeds { random =>
+      forAllRandoms { random =>
         implicit val (r, s, n) = newKit()
         implicit val store = newStore()
         testAccountTransfers (100)

--- a/store/test/com/treode/store/atomic/ScanDirectorSpec.scala
+++ b/store/test/com/treode/store/atomic/ScanDirectorSpec.scala
@@ -48,7 +48,7 @@ class ScanDirectorSpec extends FreeSpec with AsyncChecks {
   "The ScanDirector should" - {
 
     "scan from one replica" taggedAs (Periodic)  in {
-      forAllSeeds { implicit random =>
+      forAllRandoms { implicit random =>
         implicit val scheduler = StubScheduler.random (random)
         implicit val network = StubNetwork (random)
         val h = StubAtomicHost.install() .expectPass()
@@ -58,7 +58,7 @@ class ScanDirectorSpec extends FreeSpec with AsyncChecks {
       }}
 
     "scan from three replicas" taggedAs (Periodic) in {
-      forAllSeeds { implicit random =>
+      forAllRandoms { implicit random =>
         implicit val scheduler = StubScheduler.random (random)
         implicit val network = StubNetwork (random)
         val h = StubAtomicHost.install() .expectPass()

--- a/store/test/com/treode/store/catalog/BrokerSpec.scala
+++ b/store/test/com/treode/store/catalog/BrokerSpec.scala
@@ -263,11 +263,11 @@ class BrokerProperties extends PropSpec with AsyncChecks {
     }}
 
   property ("The broker should distribute catalogs", Intensive, Periodic) {
-    forAllSeeds { random =>
+    forAllRandoms { random =>
       checkUnity (random, 0.0)
     }}
 
   property ("The broker should distribute catalogs with a flakey network", Intensive, Periodic) {
-    forAllSeeds { random =>
+    forAllRandoms { random =>
       checkUnity (random, 0.1)
     }}}

--- a/store/test/com/treode/store/catalog/CatalogSpec.scala
+++ b/store/test/com/treode/store/catalog/CatalogSpec.scala
@@ -90,7 +90,7 @@ class CatalogSpec extends FreeSpec with AsyncChecks {
 
       "stable hosts and a reliable network" taggedAs (Intensive, Periodic) in {
         var summary = new Summary
-        forAllSeeds { implicit random =>
+        forAllRandoms { implicit random =>
           implicit val scheduler = StubScheduler.random (random)
           implicit val network = StubNetwork (random)
           val hs = Seq.fill (3) (new StubCatalogHost (random.nextLong))
@@ -104,7 +104,7 @@ class CatalogSpec extends FreeSpec with AsyncChecks {
 
       "stable hosts and a flakey network" taggedAs (Intensive, Periodic) in {
         var summary = new Summary
-        forAllSeeds { implicit random =>
+        forAllRandoms { implicit random =>
           implicit val scheduler = StubScheduler.random (random)
           implicit val network = StubNetwork (random)
           val hs = Seq.fill (3) (new StubCatalogHost (random.nextLong))
@@ -129,7 +129,7 @@ class CatalogSpec extends FreeSpec with AsyncChecks {
     }
 
     "distribute one issue of a catalog" in {
-      forAllSeeds { random =>
+      forAllRandoms { random =>
         implicit val (scheduler, hs, h1, _) = setup (random)
         h1.catalogs.issue (cat1) (1, 0x658C1274DE7CFA8EL) .expectPass()
         scheduler.run (timers = true, count = 500)
@@ -138,7 +138,7 @@ class CatalogSpec extends FreeSpec with AsyncChecks {
       }}
 
     "distribute two issues of a catalog, one after the other" in {
-      forAllSeeds { random =>
+      forAllRandoms { random =>
         implicit val (scheduler, hs, h1, _) = setup (random)
         h1.catalogs.issue (cat1) (1, 0x658C1274DE7CFA8EL) .expectPass()
         h1.catalogs.issue (cat1) (2, 0x48B944DD188FD6D1L) .expectPass()


### PR DESCRIPTION
Compound tests that run multiple individual pseudo-random tests need the seed so that they can start each pseudo-random test from the same place in the pseudo-random sequence.