### PR TITLE
Convert batches of BatchIterator from Iterator to Iterable.

### DIFF
--- a/async/src/com/treode/async/implicits/package.scala
+++ b/async/src/com/treode/async/implicits/package.scala
@@ -16,8 +16,7 @@
 
 package com.treode.async
 
-import java.lang.{Iterable => JavaIterable}
-import java.util.{Iterator => JavaIterator}
+import java.lang.{Iterable => JIterable}
 import scala.collection.JavaConversions._
 import scala.concurrent.{Future => ScalaFuture, ExecutionContext}
 import scala.util.{Failure, Random, Success, Try}
@@ -96,44 +95,26 @@ package object implicits {
       (v => cb (v recoverWith f))
   }
 
-  implicit class RichIterator [A] (iter: Iterator [A]) {
+  implicit class RichIterable [A] (iter: Iterable [A]) {
 
     def async (implicit scheduler: Scheduler): AsyncIterator [A] =
       AsyncIterator.adapt (iter)
 
     def batch (implicit scheduler: Scheduler): BatchIterator [A] =
       BatchIterator.adapt (iter)
-  }
-
-  implicit class RichIterable [A] (iter: Iterable [A]) {
-
-    def async (implicit scheduler: Scheduler): AsyncIterator [A] =
-      AsyncIterator.adapt (iter.iterator)
-
-    def batch (implicit scheduler: Scheduler): BatchIterator [A] =
-      BatchIterator.adapt (iter.iterator)
 
     def indexed = iter.zipWithIndex.latch
 
     object latch extends IterableLatch (iter, iter.size)
   }
 
-  implicit class RichJavaIterator [A] (iter: JavaIterator [A]) {
+  implicit class RichJavaIterable [A] (iter: JIterable [A]) {
 
     def async (implicit scheduler: Scheduler): AsyncIterator [A] =
       AsyncIterator.adapt (iter)
 
     def batch (implicit scheduler: Scheduler): BatchIterator [A] =
       BatchIterator.adapt (iter)
-  }
-
-  implicit class RichJavaIterable [A] (iter: JavaIterable [A]) {
-
-    def async (implicit scheduler: Scheduler): AsyncIterator [A] =
-      AsyncIterator.adapt (iter.iterator)
-
-    def batch (implicit scheduler: Scheduler): BatchIterator [A] =
-      BatchIterator.adapt (iter.iterator)
 
     def indexed = iter.zipWithIndex.latch
 

--- a/async/test/com/treode/async/AsyncIteratorSpec.scala
+++ b/async/test/com/treode/async/AsyncIteratorSpec.scala
@@ -130,7 +130,7 @@ class AsyncIteratorSpec extends FreeSpec {
           else
             x
       iter.whilst (_ < 5) (x => supply (seen += x)) .fail [DistinguishedException]
-      assertResult (Set (1, 2)) (seen)
+      assertResult (Set.empty) (seen)
     }
 
     "pass througn an exception from the predicate" in {

--- a/async/test/com/treode/async/AsyncIteratorTestTools.scala
+++ b/async/test/com/treode/async/AsyncIteratorTestTools.scala
@@ -61,9 +61,9 @@ object AsyncIteratorTestTools {
   /** A batch iterator over each given batch. */
   def batch [A] (xs: Seq [Seq [A]]) (implicit s: StubScheduler): BatchIterator [A] =
     new BatchIterator [A] {
-      val iter = xs.iterator
-      def batch (f: Iterator [A] => Async [Unit]): Async [Unit] =
-        s.whilst (iter.hasNext) (f (iter.next.iterator))
+      val i = xs.iterator
+      def batch (f: Iterable [A] => Async [Unit]): Async [Unit] =
+        s.whilst (i.hasNext) (f (i.next))
     }
 
   /** An async iterator over each given value. */

--- a/async/test/com/treode/async/BatchIteratorSpec.scala
+++ b/async/test/com/treode/async/BatchIteratorSpec.scala
@@ -86,7 +86,7 @@ class BatchIteratorSpec extends FreeSpec {
 
   "flatMap should" - {
 
-    def inner = Iterator (1, 2, 3)
+    def inner = Iterable (1, 2, 3)
 
     "work with the for keyword" in {
       implicit val scheduler = StubScheduler.random()
@@ -202,7 +202,7 @@ class BatchIteratorSpec extends FreeSpec {
           else
             x
       iter.whilst (_ < 5) (x => supply (seen += x)) .fail [DistinguishedException]
-      assertResult (Set (1, 2)) (seen)
+      assertResult (Set.empty) (seen)
     }
 
     "pass througn an exception from the predicate" in {

--- a/disk/src/com/treode/disk/Compactor.scala
+++ b/disk/src/com/treode/disk/Compactor.scala
@@ -29,7 +29,7 @@ import PageLedger.Groups
 private class Compactor (kit: DiskKit) {
   import kit.{config, drives, releaser, scheduler}
 
-  type DrainReq = Iterator [SegmentPointer]
+  type DrainReq = Iterable [SegmentPointer]
 
   val fiber = new Fiber
   var pages: PageRegistry = null
@@ -101,7 +101,7 @@ private class Compactor (kit: DiskKit) {
       } yield compact (groups, segs, true)
     } run (probed)
 
-  private def probeForDrain (iter: Iterator [SegmentPointer]): Unit =
+  private def probeForDrain (iter: Iterable [SegmentPointer]): Unit =
     guard {
       engaged = true
       for (groups <- pages.probeForDrain (iter))
@@ -170,7 +170,7 @@ private class Compactor (kit: DiskKit) {
         cleanreq = true
     }
 
-  def drain (iter: Iterator [SegmentPointer]): Unit =
+  def drain (iter: Iterable [SegmentPointer]): Unit =
     fiber.execute {
       if (!engaged)
         probeForDrain (iter)

--- a/disk/src/com/treode/disk/DiskDrive.scala
+++ b/disk/src/com/treode/disk/DiskDrive.scala
@@ -131,13 +131,13 @@ private class DiskDrive (
       IntSet ((pageSeg.num +: logSegs.toSeq).sorted: _*)
   }
 
-  private def _cleanable: Iterator [SegmentPointer] = {
+  private def _cleanable: Iterable [SegmentPointer] = {
     val skip = _protected.add (compacting)
-    for (seg <- alloc .cleanable (skip) .iterator)
+    for (seg <- alloc .cleanable (skip))
       yield SegmentPointer (this, segmentBounds (seg))
   }
 
-  def cleanable(): Async [Iterator [SegmentPointer]] =
+  def cleanable(): Async [Iterable [SegmentPointer]] =
     fiber.supply {
       _cleanable
     }
@@ -166,7 +166,7 @@ private class DiskDrive (
       PageLedger.write (pageLedger.clone(), file, geom, pageSeg.base, pageHead)
     }
 
-  def drain(): Async [Iterator [SegmentPointer]] =
+  def drain(): Async [Iterable [SegmentPointer]] =
     fiber.guard {
       for {
         _ <- latch (logmp.pause(), pagemp.close())

--- a/disk/src/com/treode/disk/DiskDrives.scala
+++ b/disk/src/com/treode/disk/DiskDrives.scala
@@ -84,7 +84,7 @@ private class DiskDrives (kit: DiskKit) {
     for {
       segs <- draining.latch.collect (_.drain())
     } yield {
-      compactor.drain (segs.iterator.flatten)
+      compactor.drain (segs.flatten)
       queue.launch()
       log.openedDrives (attached)
       if (!draining.isEmpty)
@@ -199,7 +199,7 @@ private class DiskDrives (kit: DiskKit) {
         segs <- drainDrives.latch.collect (_.drain())
       } yield {
         checkpointer.checkpoint()
-            .ensure (compactor.drain (segs.iterator.flatten))
+            .ensure (compactor.drain (segs.flatten))
             .run (ignore)
         log.drainingDrives (drainPaths)
       }}
@@ -240,11 +240,11 @@ private class DiskDrives (kit: DiskKit) {
       drives.values.latch.collate (_.mark())
     }
 
-  def cleanable(): Async [Iterator [SegmentPointer]] =  {
+  def cleanable(): Async [Iterable [SegmentPointer]] =  {
     guard {
       for {
         segs <- drives.values.filterNot (_.draining) .latch.collect (_.cleanable())
-      } yield segs.iterator.flatten
+      } yield segs.flatten
     }}
 
 def fetch [P] (desc: PageDescriptor [_, P], pos: Position): Async [P] =

--- a/disk/src/com/treode/disk/IntSet.scala
+++ b/disk/src/com/treode/disk/IntSet.scala
@@ -20,7 +20,7 @@ import scala.collection.JavaConversions._
 import com.googlecode.javaewah.{EWAHCompressedBitmap => Bitmap}
 import com.treode.pickle.{Pickler, PickleContext, UnpickleContext}
 
-private class IntSet private (private val bitmap: Bitmap) {
+private class IntSet private (private val bitmap: Bitmap) extends Iterable [Int] {
 
   def this() = this (Bitmap.bitmapOf())
 
@@ -51,14 +51,11 @@ private class IntSet private (private val bitmap: Bitmap) {
   def min: Int =
     bitmap.iterator.next
 
-  def size: Int =
-    bitmap.cardinality()
-
   def iterator: Iterator [Int] =
     asScalaIterator (bitmap.iterator.map (_.toInt))
 
-  def toSet: Set [Int] =
-    iterator.toSet
+  override def size: Int =
+    bitmap.cardinality()
 
   override def hashCode: Int = bitmap.hashCode
 

--- a/disk/src/com/treode/disk/LogIterator.scala
+++ b/disk/src/com/treode/disk/LogIterator.scala
@@ -53,7 +53,7 @@ private class LogIterator private (
   private var pagePos = Option.empty [Long]
   private var pageLedger = new PageLedger
 
-  class Batch (f: Iterator [(Long, Unit => Any)] => Async [Unit], cb: Callback [Unit]) {
+  class Batch (f: Iterable [(Long, Unit => Any)] => Async [Unit], cb: Callback [Unit]) {
 
     val _read: Callback [Int] = {
       case Success (v) => cb.defer (read (v))
@@ -147,14 +147,14 @@ private class LogIterator private (
           val entry = records.read (id.id, logBuf, len - end + start)
           logPos += len + 4
           checkpointer.tally(len + 4, 1)
-          f (Iterator ((batch, entry))) run (_next)
+          f (Iterable ((batch, entry))) run (_next)
       }}
 
     def next() {
       file.deframe (logBuf, logPos, blockBits) run (_read)
     }}
 
-  def batch (f: Iterator [(Long, Unit => Any)] => Async [Unit]): Async [Unit] =
+  def batch (f: Iterable [(Long, Unit => Any)] => Async [Unit]): Async [Unit] =
     async (new Batch (f, _) .next())
 
   def pages(): (SegmentBounds, Long, PageLedger, Boolean) =

--- a/disk/src/com/treode/disk/PageRegistry.scala
+++ b/disk/src/com/treode/disk/PageRegistry.scala
@@ -57,7 +57,7 @@ private class PageRegistry (kit: DiskKit) extends AbstractPageRegistry {
       yield ledger.liveBytes (liveGroups)
   }
 
-  def probeByUtil (iter: Iterator [SegmentPointer], threshold: Int):
+  def probeByUtil (iter: Iterable [SegmentPointer], threshold: Int):
       Async [(Seq [SegmentPointer], Groups)] = {
 
     val candidates =
@@ -86,7 +86,7 @@ private class PageRegistry (kit: DiskKit) extends AbstractPageRegistry {
       (segs, groups)
     }}
 
-  def probeForDrain (iter: Iterator [SegmentPointer]): Async [Groups] = {
+  def probeForDrain (iter: Iterable [SegmentPointer]): Async [Groups] = {
 
     val merger = new Merger
     engaged = true

--- a/disk/stub/com/treode/disk/stubs/StubDiskDrive.scala
+++ b/disk/stub/com/treode/disk/stubs/StubDiskDrive.scala
@@ -98,9 +98,9 @@ class StubDiskDrive (implicit random: Random) {
       cb.pass (pages .get (pos) .getOrThrow (new Exception (s"Page $pos not found")))
     }
 
-  private [stubs] def cleanable(): Iterator [(Long, StubPage)] =
+  private [stubs] def cleanable(): Iterable [(Long, StubPage)] =
     synchronized {
-      pages.iterator
+      pages
     }
 
   private [stubs] def free (pos: Seq [Long]): Unit =

--- a/disk/stub/com/treode/disk/stubs/StubPageRegistry.scala
+++ b/disk/stub/com/treode/disk/stubs/StubPageRegistry.scala
@@ -36,7 +36,7 @@ private class StubPageRegistry (releaser: EpochReleaser) (implicit
 
   import config.compactionProbability
 
-  def probe (iter: Iterator [(Long, StubPage)]): Async [(Groups, Seq [Long])] = {
+  def probe (iter: Iterable [(Long, StubPage)]): Async [(Groups, Seq [Long])] = {
     val merger = new Merger
     val segments = Seq.newBuilder [Long]
     iter.async.foreach { case (offset, page) =>

--- a/examples/movies/server/src/movies/PhysicalModel.scala
+++ b/examples/movies/server/src/movies/PhysicalModel.scala
@@ -122,7 +122,7 @@ private object PhysicalModel {
     def list (window: Window) (implicit store: Store): BatchIterator [AM.Movie] =
       for {
         cell <- MovieTable.scan (
-            window = window, 
+            window = window,
             batch = Batch (4000, 1 << 18))
         if cell.value.isDefined
       } yield {
@@ -343,7 +343,7 @@ private object PhysicalModel {
     def list (window: Window) (implicit store: Store): BatchIterator [AM.Actor] =
       for {
         cell <- ActorTable.scan (
-            window = window, 
+            window = window,
             batch = Batch (4000, 1 << 18))
         if cell.value.isDefined
       } yield {
@@ -452,11 +452,11 @@ private object PhysicalModel {
     def list (window: Window) (implicit store: Store): BatchIterator [AM.Role] =
       for {
         cell <- RolesTable.scan (
-            window = window,  
+            window = window,
             batch = Batch (4000, 1 << 18))
         if cell.value.isDefined
         val actorId = cell.key
-        role <- cell.value.get.roles.iterator
+        role <- cell.value.get.roles
       } yield {
         AM.Role (actorId, role.movieId, role.role)
       }

--- a/store/src/com/treode/store/atomic/ScanDirector.scala
+++ b/store/src/com/treode/store/atomic/ScanDirector.scala
@@ -38,7 +38,7 @@ private class ScanDirector (
   import kit.{cluster, library, random, scheduler}
   import kit.config.scanBatchBackoff
 
-  private class Batch (body: Iterator [Cell] => Async [Unit], cb: Callback [Unit]) {
+  private class Batch (body: Iterable [Cell] => Async [Unit], cb: Callback [Unit]) {
 
     val fiber = new Fiber
 
@@ -121,7 +121,7 @@ private class ScanDirector (
       if (!xs.isEmpty) {
         // We have data to give, and we proactively asked a deputy for new data.
         ready = false
-        scheduler.execute (guard (body (xs.iterator)) run (took _))
+        scheduler.execute (guard (body (xs)) run (took _))
       } else if (taken) {
         // There's nothing to give, no deputies responded while the client body executed.
         val last = this.last
@@ -176,7 +176,7 @@ private class ScanDirector (
         scan (table, last, window, slice, batch) (from, port)
       }}}
 
-  def batch (f: Iterator [Cell] => Async [Unit]): Async [Unit] =
+  def batch (f: Iterable [Cell] => Async [Unit]): Async [Unit] =
     async (new Batch (f, _))
 }
 

--- a/store/src/com/treode/store/tier/CellPage.scala
+++ b/store/src/com/treode/store/tier/CellPage.scala
@@ -26,9 +26,6 @@ private class CellPage (val entries: Array [Cell]) extends TierPage {
   def get (i: Int): Cell =
     entries (i)
 
-  def iterator: Iterator [Cell] =
-    entries.iterator
-
   def ceiling (start: Bound [Key]): Int = {
     val target = Cell (start.bound.key, start.bound.time, None)
     val i = Arrays.binarySearch (entries, target, Cell)

--- a/store/src/com/treode/store/tier/TierIterator.scala
+++ b/store/src/com/treode/store/tier/TierIterator.scala
@@ -16,7 +16,6 @@
 
 package com.treode.store.tier
 
-import scala.collection.JavaConversions._
 import scala.util.{Failure, Success}
 
 import com.treode.async.{Async, BatchIterator, Callback, Scheduler}
@@ -33,7 +32,7 @@ private abstract class TierIterator (
     disk: Disk
 ) extends CellIterator {
 
-  class Batch (f: Iterator [Cell] => Async [Unit], cb: Callback [Unit]) {
+  class Batch (f: Iterable [Cell] => Async [Unit], cb: Callback [Unit]) {
 
     import desc.pager
 
@@ -118,7 +117,7 @@ private abstract class TierIterator (
       }}
 
     def body (page: CellPage, index: Int): Option [Unit] = {
-      f (page.iterator.drop (index)) run (_next)
+      f (page.entries.drop (index)) run (_next)
       None
     }
 
@@ -156,7 +155,7 @@ private object TierIterator {
       disk: Disk
   ) extends TierIterator (desc, root) {
 
-    def batch (f: Iterator [Cell] => Async [Unit]): Async [Unit] =
+    def batch (f: Iterable [Cell] => Async [Unit]): Async [Unit] =
       async (new Batch (f, _) .start())
   }
 
@@ -168,7 +167,7 @@ private object TierIterator {
       disk: Disk
   ) extends TierIterator (desc, root) {
 
-    def batch (f: Iterator [Cell] => Async [Unit]): Async [Unit] =
+    def batch (f: Iterable [Cell] => Async [Unit]): Async [Unit] =
       async (new Batch (f, _) .start (start))
   }
 
@@ -192,7 +191,7 @@ private object TierIterator {
     (new FromKey (desc, root, start))
 
   def adapt (tier: MemTier) (implicit scheduler: Scheduler): CellIterator =
-    tier.entrySet.iterator.map (memTierEntryToCell _) .batch
+    tier.entrySet.batch.map (memTierEntryToCell _)
 
   def adapt (tier: MemTier, start: Bound [Key]) (implicit scheduler: Scheduler): CellIterator =
     adapt (tier.tailMap (start.bound, start.inclusive))

--- a/store/stub/com/treode/store/stubs/StubStore.scala
+++ b/store/stub/com/treode/store/stubs/StubStore.scala
@@ -17,7 +17,7 @@
 package com.treode.store.stubs
 
 import java.util.concurrent.{ConcurrentHashMap, ConcurrentSkipListMap}
-import scala.collection.JavaConversions
+import scala.collection.JavaConversions._
 
 import com.treode.async.{Async, BatchIterator, Scheduler}
 import com.treode.async.implicits._
@@ -27,7 +27,6 @@ import com.treode.store._
 import com.treode.store.locks.LockSpace
 
 import Async.{async, guard}
-import JavaConversions._
 
 class StubStore (implicit scheduler: Scheduler) extends Store {
 
@@ -121,10 +120,10 @@ class StubStore (implicit scheduler: Scheduler) extends Store {
       } yield {
         data
             .tailMap (StubKey (table, start.bound.key, start.bound.time), start.inclusive)
-            .iterator
-            .takeWhile (_._1.table == table)
-            .map {case (key, value) => Cell (key.key, key.time, value)}
+            .headMap (StubKey (table.id + 1, Bytes.empty, TxClock.MaxValue))
+            .entrySet
             .batch
+            .map (e => Cell (e.getKey.key, e.getKey.time, e.getValue))
             .slice (table, slice)
             .window (window)
       }}

--- a/store/test/com/treode/store/FiltersSpec.scala
+++ b/store/test/com/treode/store/FiltersSpec.scala
@@ -35,7 +35,7 @@ class FiltersSpec extends FreeSpec {
       val out = items .map (_._2) .flatten
       s"handle ${testStringOf (in)}" in {
         implicit val scheduler = StubScheduler.random()
-        assertCells (out: _*) (in.iterator.batch.dedupe)
+        assertCells (out: _*) (in.batch.dedupe)
       }}
 
     val apple1 = (
@@ -84,7 +84,7 @@ class FiltersSpec extends FreeSpec {
       val out = item._2
       s"handle ${testStringOf (in)}" in {
         implicit val scheduler = StubScheduler.random()
-        assertCells (out: _*) (in.iterator.batch.retire (7))
+        assertCells (out: _*) (in.batch.retire (7))
       }}
 
     val apple1 = (

--- a/store/test/com/treode/store/WindowSpec.scala
+++ b/store/test/com/treode/store/WindowSpec.scala
@@ -43,7 +43,7 @@ class WindowSpec extends FreeSpec {
       val out = items .map (_._2) .flatten
       s"filter ${testStringOf (in)}" in {
         implicit val scheduler = StubScheduler.random()
-        assertCells (out: _*) (in.iterator.batch.window (filter))
+        assertCells (out: _*) (in.batch.window (filter))
       }}
 
     val apples = Seq (
@@ -135,7 +135,7 @@ class WindowSpec extends FreeSpec {
       val out = items .map (_._2) .flatten
       s"handle ${testStringOf (in)}" in {
         implicit val scheduler = StubScheduler.random()
-        assertCells (out: _*) (in.iterator.batch.window (filter))
+        assertCells (out: _*) (in.batch.window (filter))
       }}
 
     val apple1 = (
@@ -191,7 +191,7 @@ class WindowSpec extends FreeSpec {
       val out = items .map (_._2) .flatten
       s"handle ${testStringOf (in)}" in {
         implicit val scheduler = StubScheduler.random()
-        assertCells (out: _*) (in.iterator.batch.window (filter))
+        assertCells (out: _*) (in.batch.window (filter))
       }}
 
     val apple1 = (

--- a/store/test/com/treode/store/atomic/StubScanDeputy.scala
+++ b/store/test/com/treode/store/atomic/StubScanDeputy.scala
@@ -56,7 +56,6 @@ private class StubScanDeputy (
   ScanDeputy.scan.listen { case ((table, start, window, slice, batch), from) =>
     tables (table)
     .from (start.bound)
-    .iterator
     .filter (start <* _._1)
     .map {case (key, value) => Cell (key.key, key.time, value)}
     .batch


### PR DESCRIPTION
This change allows the batch processor to iterate the batch multiple times. In current implementations of BatchIterator, we are able to upgrade from Iterator to Iterable without any problem.