### PR TITLE
Stubs should import, not extend, Assertions.

### DIFF
--- a/async/stub/com/treode/async/stubs/CallbackCaptor.scala
+++ b/async/stub/com/treode/async/stubs/CallbackCaptor.scala
@@ -18,10 +18,10 @@ package com.treode.async.stubs
 
 import scala.util.{Failure, Success, Try}
 
-import org.scalatest.Assertions
+import org.scalatest.Assertions._
 
 /** Capture the result of an asynchronous call so you may test for success or failure later. */
-class CallbackCaptor [A] private extends (Try [A] => Unit) with Assertions {
+class CallbackCaptor [A] private extends (Try [A] => Unit) {
 
   private var _invokation: Array [StackTraceElement] = null
   private var _v: A = null.asInstanceOf [A]

--- a/async/test/com/treode/async/io/AsyncFileMock.scala
+++ b/async/test/com/treode/async/io/AsyncFileMock.scala
@@ -27,10 +27,10 @@ import scala.util.{Success, Failure}
 import com.treode.async.Callback
 import com.treode.async.implicits._
 import com.treode.async.stubs.StubScheduler
-import org.scalatest.Assertions
+import org.scalatest.Assertions._
 
 /** ScalaMock refuses to mock AsynchronousFileChannel. */
-class AsyncFileMock extends AsynchronousFileChannel with Assertions {
+class AsyncFileMock extends AsynchronousFileChannel {
 
   private class Expectation {
     def read (dst: ByteBuffer, position: Long) {

--- a/async/test/com/treode/async/io/AsyncSocketMock.scala
+++ b/async/test/com/treode/async/io/AsyncSocketMock.scala
@@ -28,10 +28,10 @@ import scala.util.{Failure, Success}
 import com.treode.async.Callback
 import com.treode.async.implicits._
 import com.treode.async.stubs.StubScheduler
-import org.scalatest.Assertions
+import org.scalatest.Assertions._
 
 /** ScalaMock refuses to mock AsynchronousSocketChannel. */
-class AsyncSocketMock extends AsynchronousSocketChannel (null) with Assertions {
+class AsyncSocketMock extends AsynchronousSocketChannel (null) {
 
   private class Expectation {
     def read (dst: ByteBuffer) {

--- a/cluster/stub/com/treode/cluster/stubs/MessageCaptor.scala
+++ b/cluster/stub/com/treode/cluster/stubs/MessageCaptor.scala
@@ -17,22 +17,20 @@
 package com.treode.cluster.stubs
 
 import java.util.ArrayList
-import scala.collection.JavaConversions
+import scala.collection.JavaConversions._
 import scala.util.Random
 
 import com.treode.async.stubs.{CallbackCaptor, StubScheduler}
 import com.treode.cluster.{HostId, MessageDescriptor, PeerRegistry, PortId, Peer}
 import com.treode.pickle.Pickler
-import org.scalatest.Assertions
-
-import JavaConversions._
+import org.scalatest.Assertions._
 
 class MessageCaptor (
     val localId: HostId
 ) (implicit
     random: Random,
     network: StubNetwork
-) extends StubPeer with Assertions {
+) extends StubPeer {
 
   private val peers: PeerRegistry =
     new PeerRegistry (localId, new StubConnection (_, localId, network))


### PR DESCRIPTION
The method namespace of various stubs and captors was polluted by methods from the Assertions class of ScalaTest. This made it difficult to send from their ScalaDoc what the stubs and captors provided.