### PR TITLE
Simplify API for AsyncQueue and add ScalaDoc.

### DIFF
--- a/async/test/com/treode/async/AsyncQueueSpec.scala
+++ b/async/test/com/treode/async/AsyncQueueSpec.scala
@@ -32,18 +32,15 @@ class AsyncQueueSpec extends FlatSpec {
   class TestQueue (implicit scheduler: StubScheduler) {
 
     val fiber = new Fiber
-    val queue = AsyncQueue (fiber) (next())
+    val queue = new AsyncQueue (fiber) (reengage _)
     var callbacks = new ArrayDeque [Callback [Unit]]
     var captor = AsyncCaptor [Unit]
 
     queue.launch()
 
-    def next(): Option [Runnable] = {
-      if (callbacks.isEmpty) {
-        None
-      } else {
+    def reengage(): Unit =
+      if (!callbacks.isEmpty)
         queue.run (callbacks.remove()) (captor.start())
-      }}
 
     def start(): CallbackCaptor [Unit] = {
       val cb = queue.async [Unit] (cb => callbacks.add (cb)) .capture()

--- a/disk/src/com/treode/disk/DiskDrives.scala
+++ b/disk/src/com/treode/disk/DiskDrives.scala
@@ -53,7 +53,7 @@ private class DiskDrives (kit: DiskKit) {
 
   val queue = AsyncQueue (fiber) {
     if (closed) {
-      None
+      // noop
     } else if (!closereqs.isEmpty) {
       val cb = fanout [Unit] (closereqs)
       closereqs = List.empty
@@ -91,7 +91,7 @@ private class DiskDrives (kit: DiskKit) {
         log.drainingDrives (draining.setBy (_.path))
     }}
 
-  def _close (cb: Callback [Unit]): Option [Runnable] =
+  def _close (cb: Callback [Unit]): Unit =
     queue.run (cb) {
       closed = true
       drives.values.latch (_.close())
@@ -107,7 +107,7 @@ private class DiskDrives (kit: DiskKit) {
       drives.values.latch.collect (_.digest)
     }
 
-  private def _attach (items: Seq [AttachItem], cb: Callback [Unit]): Option [Runnable] =
+  private def _attach (items: Seq [AttachItem], cb: Callback [Unit]): Unit =
     queue.run (cb) {
 
       val priorDisks = drives.values
@@ -155,7 +155,7 @@ private class DiskDrives (kit: DiskKit) {
       _attach (files)
     }
 
-  private def _detach (items: List [DiskDrive]): Option [Runnable] =
+  private def _detach (items: List [DiskDrive]): Unit =
     queue.run (ignore) {
 
       val keepDrives = this.drives -- (items map (_.id))
@@ -179,7 +179,7 @@ private class DiskDrives (kit: DiskKit) {
       detachreqs ::= disk
     }
 
-  private def _drain (items: Seq [Path], cb: Callback [Unit]): Option [Runnable] =
+  private def _drain (items: Seq [Path], cb: Callback [Unit]): Unit =
     queue.run (cb) {
 
       val byPath = drives.values.mapBy (_.path)
@@ -213,7 +213,7 @@ private class DiskDrives (kit: DiskKit) {
       drainreqs = drainreqs.enqueue (items, cb)
     }
 
-  private def _checkpoint (marks: Map [Int, Long], cb: Callback [Unit]): Option [Runnable] =
+  private def _checkpoint (marks: Map [Int, Long], cb: Callback [Unit]): Unit =
     queue.run (cb) {
       val bootgen = this.bootgen + 1
       val attached = drives.values.setBy (_.path)

--- a/store/src/com/treode/store/atomic/AtomicMover.scala
+++ b/store/src/com/treode/store/atomic/AtomicMover.scala
@@ -37,7 +37,7 @@ private class AtomicMover (kit: AtomicKit) {
   import kit.library.{atlas, releaser}
 
   private val fiber = new Fiber
-  private val queue = AsyncQueue (fiber) (next())
+  private val queue = new AsyncQueue (fiber) (next _)
   private val tracker = new Tracker
   private var callbacks = List.empty [Callback [Unit]]
 
@@ -144,14 +144,13 @@ private class AtomicMover (kit: AtomicKit) {
       case _: JTimeoutException => continue (start)
     }
 
-  def next(): Option [Runnable] =
+  def next(): Unit =
     (tracker.deque: @unchecked) match {
       case Some ((Range (start: Point.Middle, end), targets)) =>
-        queue.run (ignore) (rebalance (start, end, targets))
+        queue.begin (rebalance (start, end, targets))
       case None =>
         callbacks foreach (_.pass (()))
         callbacks = List.empty
-        None
     }
 
   def rebalance (targets: Targets): Async [Unit] =

--- a/store/src/com/treode/store/paxos/PaxosMover.scala
+++ b/store/src/com/treode/store/paxos/PaxosMover.scala
@@ -37,7 +37,7 @@ private class PaxosMover (kit: PaxosKit) {
   import kit.library.{atlas, releaser}
 
   private val fiber = new Fiber
-  private val queue = AsyncQueue (fiber) (next())
+  private val queue = new AsyncQueue (fiber) (next _)
   private val tracker = new Tracker
   private var callbacks = List.empty [Callback [Unit]]
 
@@ -132,14 +132,13 @@ private class PaxosMover (kit: PaxosKit) {
       case _: JTimeoutException => continue (start)
     }
 
-  def next(): Option [Runnable] =
+  def next(): Unit =
     (tracker.deque: @unchecked) match {
       case Some ((Range (start: Point.Middle, end), targets)) =>
-        queue.run (ignore) (rebalance (start, end, targets))
+        queue.begin (rebalance (start, end, targets))
       case None =>
         callbacks foreach (scheduler.pass (_, ()))
         callbacks = List.empty
-        None
     }
 
   def rebalance (targets: Targets): Async [Unit] =


### PR DESCRIPTION
This API is much simpler to explain, and yet it can mostly support the old API. This CL makes minor changes the current users of AsyncQueue. The AtomicMover and PaxosMover now use only the simpler API. The DiskDrives class continues to use the old confusing methods. That will be replaced soon, and then a later CL will remove the old methods.