### PR TITLE
Remove Fiber#guard; clean up its uses.

### DIFF
--- a/async/test/com/treode/async/FiberSpec.scala
+++ b/async/test/com/treode/async/FiberSpec.scala
@@ -118,19 +118,6 @@ class FiberSpec extends FlatSpec {
     f.async [Unit] (cb => throw new DistinguishedException) .fail [DistinguishedException]
   }
 
-  "Fiber.guard" should "report an exception through the callback" in {
-    implicit val s = StubScheduler.random()
-    val f = new Fiber
-    f.guard (throw new DistinguishedException) .fail [DistinguishedException]
-  }
-
-  it should "reject the return keyword" in {
-    implicit val s = StubScheduler.random()
-    val f = new Fiber
-    def method(): Async [Int] = f.guard (return supply (0))
-    method() .fail [ReturnException]
-  }
-
   "Fiber.supply" should "invoke the callback" in {
     implicit val s = StubScheduler.random()
     val f = new Fiber

--- a/disk/src/com/treode/disk/Compactor.scala
+++ b/disk/src/com/treode/disk/Compactor.scala
@@ -179,7 +179,8 @@ private class Compactor (kit: DiskKit) {
     }
 
   def close(): Async [Unit] =
-    fiber.guard {
-      closed = true
-      pages.close()
-    }}
+    for {
+      _ <- fiber.supply (closed = true)
+      _ <- pages.close()
+    } yield ()
+}

--- a/disk/src/com/treode/disk/DiskDrives.scala
+++ b/disk/src/com/treode/disk/DiskDrives.scala
@@ -103,8 +103,11 @@ private class DiskDrives (kit: DiskKit) {
     }
 
   def digest: Async [Seq [DriveDigest]] =
-    fiber.guard {
-      drives.values.latch.collect (_.digest)
+    for {
+      _drives <- fiber.supply (drives.values)
+      _digests <- _drives.latch.collect (_.digest)
+    } yield {
+      _digests
     }
 
   private def _attach (items: Seq [AttachItem], cb: Callback [Unit]): Unit =

--- a/store/src/com/treode/store/atomic/WriteDeputy.scala
+++ b/store/src/com/treode/store/atomic/WriteDeputy.scala
@@ -391,7 +391,7 @@ private class WriteDeputy (xid: TxId, kit: AtomicKit) {
     fiber.async (state.abort (_))
 
   def checkpoint(): Async [Unit] =
-    fiber.guard (state.checkpoint())
+    fiber.async (cb => state.checkpoint() run (cb))
 
   override def toString = state.toString
 }

--- a/store/src/com/treode/store/catalog/RecoveryKit.scala
+++ b/store/src/com/treode/store/catalog/RecoveryKit.scala
@@ -62,17 +62,17 @@ private class RecoveryKit (implicit
       (id, handler)
     }
 
-  def launch (implicit launch: Disk.Launch, cluster: Cluster): Async [Catalogs] =
-    fiber.guard {
-      import launch.disk
-      for {
-        handlers <- medics.keySet.latch.collate (close (_))
-        broker = new Broker (handlers)
-        kit = new CatalogKit (broker)
-      } yield {
-        import kit.{acceptors, proposers}
-        acceptors.attach()
-        proposers.attach()
-        broker.attach()
-        kit
-      }}}
+  def launch (implicit launch: Disk.Launch, cluster: Cluster): Async [Catalogs] = {
+    import launch.disk
+    for {
+      _medics <- fiber.supply (medics.keySet)
+      handlers <- _medics.latch.collate (close (_))
+      broker = new Broker (handlers)
+      kit = new CatalogKit (broker)
+    } yield {
+      import kit.{acceptors, proposers}
+      acceptors.attach()
+      proposers.attach()
+      broker.attach()
+      kit
+    }}}

--- a/store/src/com/treode/store/paxos/Acceptor.scala
+++ b/store/src/com/treode/store/paxos/Acceptor.scala
@@ -295,7 +295,7 @@ private class Acceptor (val key: Bytes, val time: TxClock, kit: PaxosKit) {
     fiber.execute (state.choose (chosen))
 
   def checkpoint(): Async [Unit] =
-    fiber.guard (state.checkpoint())
+    fiber.async (cb => state.checkpoint() run (cb))
 
   def dispose(): Unit =
     releaser.leave (epoch)


### PR DESCRIPTION
Fiber#guard gave a misleading impression about what it serialized, and that led to mistakes. Removed Fiber#guard and fixed up places where it was being used. Now it's much clearer what the fiber is serializing, and what asynchronous operations may be interleaved with tasks on the fiber.