### PR TITLE
Fix request logging for finagle and movies examples

### DIFF
--- a/examples/finagle/src/main/scala/example/Main.scala
+++ b/examples/finagle/src/main/scala/example/Main.scala
@@ -52,11 +52,11 @@ class Serve extends TwitterServer with StoreKit with TreodeAdmin {
     val server = Http.serve (
       httpAddr,
       NettyToFinagle andThen
+      LoggingFilter andThen
       ExceptionFilter andThen
       BadRequestFilter andThen
       JsonExceptionFilter andThen
       PeersFilter ("/peers", controller) andThen
-      LoggingFilter andThen
       resource)
 
     onExit {

--- a/examples/finagle/src/main/scala/example/Main.scala
+++ b/examples/finagle/src/main/scala/example/Main.scala
@@ -56,6 +56,7 @@ class Serve extends TwitterServer with StoreKit with TreodeAdmin {
       BadRequestFilter andThen
       JsonExceptionFilter andThen
       PeersFilter ("/peers", controller) andThen
+      LoggingFilter andThen
       resource)
 
     onExit {

--- a/examples/finagle/src/main/scala/example/package.scala
+++ b/examples/finagle/src/main/scala/example/package.scala
@@ -25,6 +25,9 @@ import com.treode.store.{Bytes, TableId, TxClock}
 import com.treode.twitter.finagle.http.{RichResponse, BadRequestException, RichRequest}
 import com.twitter.finagle.http.{Request, Response, Status}
 import org.jboss.netty.handler.codec.http.HttpResponseStatus
+import com.twitter.finagle.http.filter.{CommonLogFormatter, LoggingFilter}
+import com.twitter.logging.Logger
+
 
 package object example {
 
@@ -77,6 +80,8 @@ package object example {
       rsp.json = iter
       rsp
     }}
+
+  object LoggingFilter extends LoggingFilter (Logger ("access"), new CommonLogFormatter)
 
   implicit class RichAny (v: Any) {
 

--- a/examples/movies/server/src/movies/Main.scala
+++ b/examples/movies/server/src/movies/Main.scala
@@ -63,7 +63,6 @@ class Serve extends TwitterServer with StoreKit with TreodeAdmin {
       BadRequestFilter andThen
       JsonExceptionFilter andThen
       PeersFilter ("/peers", controller) andThen
-      LoggingFilter andThen
       router.result)
 
     onExit {

--- a/examples/movies/server/src/movies/Main.scala
+++ b/examples/movies/server/src/movies/Main.scala
@@ -63,6 +63,7 @@ class Serve extends TwitterServer with StoreKit with TreodeAdmin {
       BadRequestFilter andThen
       JsonExceptionFilter andThen
       PeersFilter ("/peers", controller) andThen
+      LoggingFilter andThen
       router.result)
 
     onExit {


### PR DESCRIPTION
Finagle examples are not logging requests.
This fix will produce entries like this on the console:

INF [20150216-18:29:27.628] access: 0:0:0:0:0:0:0:1 - - [17/Feb/2015:02:29:27 +0000] "PUT /table/0x1001?key=1001x HTTP/1.1" 200 - 362 "curl/7.37.1"

