### PR TITLE
Remove fiber from Dispatcher, and add setter for batch.

### DIFF
--- a/disk/src/com/treode/disk/DiskKit.scala
+++ b/disk/src/com/treode/disk/DiskKit.scala
@@ -32,8 +32,9 @@ private class DiskKit (
     val config: Disk.Config
 ) {
 
-  val logd = new Dispatcher [PickledRecord] (logBatch)
-  val paged = new Dispatcher [PickledPage] (0L)
+  val logd = new Dispatcher [PickledRecord]
+  logd.batch = logBatch
+  val paged = new Dispatcher [PickledPage]
   val drives = new DiskDrives (this)
   val checkpointer = new Checkpointer (this)
   val releaser = new EpochReleaser

--- a/disk/src/com/treode/disk/Dispatcher.scala
+++ b/disk/src/com/treode/disk/Dispatcher.scala
@@ -16,26 +16,25 @@
 
 package com.treode.disk
 
-import java.util.{ArrayDeque}
+import java.util.ArrayDeque
 import scala.collection.mutable.UnrolledBuffer
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success}
-import com.treode.async.{Async, Callback, Fiber, Scheduler }, Async.async
+import com.treode.async.{Async, Callback, Scheduler}, Async.async
 
 /** A queue of messages. Senders (producers) send one or many messages, and receivers (consumers)
   * take all queue messages if any, or wait for the next message(s) sent. The queue maintains a
   * batch number that's incremented upon each delivery.
   */
-private class Dispatcher [M] (
-  private var counter: Long
-) (implicit
+private class Dispatcher [M] (implicit
   scheduler: Scheduler,
   mtag: ClassTag [M]
 ) {
 
   private type R = Callback [(Long, UnrolledBuffer [M])]
-  private val fiber = new Fiber
+
   private var messages = new UnrolledBuffer [M]
+  private var _batch = 0L
 
   // TODO: visible for testing, make it private
   val receivers = new ArrayDeque [R]
@@ -52,51 +51,69 @@ private class Dispatcher [M] (
 
   /** Deliver the messages to the receiver. */
   private def engage (receiver: R, messages: UnrolledBuffer [M]) {
-    counter += 1
-    scheduler.pass (receiver, (counter, messages))
+    _batch += 1
+    scheduler.pass (receiver, (_batch, messages))
   }
 
   /** True if no messages or receivers are queued.
     * @return True if no messages or receivers are queued.
     */
-  def isEmpty = messages.isEmpty && receivers.isEmpty
+  def isEmpty: Boolean =
+    synchronized (messages.isEmpty && receivers.isEmpty)
+
+  /** Peek at the next batch number. */
+  def batch: Long =
+    synchronized (_batch)
+
+  /** Raise the next batch number, if the given value exceeds the current one.
+    * @param batch The new batch number.
+    */
+  def batch_= (batch: Long): Unit =
+    synchronized {
+      if (_batch < batch) _batch = batch
+    }
 
   /** Send the message. Deliver it with an awaiting receiver, or queue it for the next receiver to
     * arrive.
     * @param message The message to send.
     */
-  def send (message: M): Unit = fiber.execute {
-    if (receivers.isEmpty)
-      messages += message
-    else
-      engage (receivers.remove(), singleton (message))
-  }
+  def send (message: M): Unit =
+    synchronized {
+      if (receivers.isEmpty)
+        messages += message
+      else
+        engage (receivers.remove(), singleton (message))
+    }
 
   /** Send the messages. Deliver them to an awaiting receiver, or queue them for the next receiver
     * to arrive.
     * @param messages The messages to send; the UnrolledBuffer will be cleared.
     */
-  def send (messages: UnrolledBuffer [M]): Unit = fiber.execute {
-    this.messages.concat (messages)
-    if (!this.messages.isEmpty && !receivers.isEmpty)
-      engage (receivers.remove(), drain())
-  }
+  def send (messages: UnrolledBuffer [M]): Unit =
+    synchronized {
+      this.messages.concat (messages)
+      if (!this.messages.isEmpty && !receivers.isEmpty)
+        engage (receivers.remove(), drain())
+    }
 
   /** Deprecated. */
   def receive (receiver: (Long, UnrolledBuffer [M]) => Any): Unit =
     receive() run {
-      case Success ( (counter, messages) ) => receiver(counter, messages)
+      case Success ((batch, messages)) => receiver (batch, messages)
       case Failure (thrown) => throw thrown
     }
 
   /** Receive all queued messages. The receiver gets all queued messages delivered promptly if any
-    * any are queued, or the receiver gets called later when some sender provides messages.
-    * @returns All messages that had been queued or recently sent.
+    * any are queued, or the receiver gets called later when some sender provides messages. The
+    * receiver also gets the batch number, which the Dispatch increments each time it delivers
+    * messages to a receiver.
+    * @returns All messages that had been queued, and the next batch number.
     */
-  def receive () : Async [(Long, UnrolledBuffer [M])] ={
-    fiber.async {cb =>
-      if(messages.isEmpty)
-      receivers.add (cb)
-    else
-      engage (cb, drain())
-    }}}
+  def receive () : Async [(Long, UnrolledBuffer [M])] =
+    async { cb =>
+      synchronized {
+        if(messages.isEmpty)
+        receivers.add (cb)
+      else
+        engage (cb, drain())
+      }}}

--- a/disk/stub/com/treode/disk/stubs/StubDisk.scala
+++ b/disk/stub/com/treode/disk/stubs/StubDisk.scala
@@ -36,7 +36,7 @@ private class StubDisk (
     config: StubDisk.Config
 ) extends Disk {
 
-  val logd = new Dispatcher [(StubRecord, Callback [Unit])] (0L)
+  val logd = new Dispatcher [(StubRecord, Callback [Unit])]
   val checkpointer = new StubCheckpointer
   val compactor = new StubCompactor (releaser)
 

--- a/disk/test/com/treode/disk/DispatcherSpec.scala
+++ b/disk/test/com/treode/disk/DispatcherSpec.scala
@@ -28,7 +28,7 @@ class DispatcherSpec extends FlatSpec {
 
   "The Dispatcher" should "queue one message for a later receiver" in {
     implicit val scheduler = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
+    val dsp = new Dispatcher [Int]
     dsp.send (1)
     val captor = dsp.receive().capture()
     captor.expectPass ((1, Seq (1)))
@@ -37,7 +37,7 @@ class DispatcherSpec extends FlatSpec {
 
   it should "deliver one message to an earlier receiver" in {
     implicit val scheduler = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
+    val dsp = new Dispatcher [Int]
     val captor = dsp.receive().capture()
     dsp.send (1)
     captor.expectPass ((1, Seq (1)))
@@ -46,7 +46,7 @@ class DispatcherSpec extends FlatSpec {
 
   it should "queue several messages for a later receiver" in {
     implicit val schedule = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
+    val dsp = new Dispatcher [Int]
     dsp.send (1)
     dsp.send (2)
     val captor = dsp.receive().capture()
@@ -56,7 +56,7 @@ class DispatcherSpec extends FlatSpec {
 
   it should "queue one batch of messages for a later receiver" in {
     implicit val scheduler = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
+    val dsp = new Dispatcher [Int]
     dsp.send (UnrolledBuffer (1, 2, 3))
     val captor = dsp.receive().capture()
     captor.expectPass ((1, Seq (1, 2, 3)))
@@ -65,7 +65,7 @@ class DispatcherSpec extends FlatSpec {
 
   it should "deliver one batch of messages to an earlier receiver" in {
     implicit val scheduler = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
+    val dsp = new Dispatcher [Int]
     val captor = dsp.receive().capture()
     dsp.send (UnrolledBuffer (1, 2, 3))
     captor.expectPass ((1, Seq (1, 2, 3)))
@@ -74,7 +74,7 @@ class DispatcherSpec extends FlatSpec {
 
   it should "queue several batches of messages for a later receiver" in {
     implicit val schedule = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
+    val dsp = new Dispatcher [Int]
     dsp.send (UnrolledBuffer (1, 2))
     dsp.send (UnrolledBuffer (3, 4))
     val captor = dsp.receive().capture()
@@ -84,7 +84,7 @@ class DispatcherSpec extends FlatSpec {
 
   it should "queue a message and a message batch for a later receiver" in {
     implicit val schedule = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
+    val dsp = new Dispatcher [Int]
     dsp.send (1)
     dsp.send (UnrolledBuffer (2, 3))
     val captor = dsp.receive().capture()
@@ -94,7 +94,7 @@ class DispatcherSpec extends FlatSpec {
 
   it should "queue a message batch and a message for a later receiver" in {
     implicit val schedule = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
+    val dsp = new Dispatcher [Int]
     dsp.send (UnrolledBuffer (1, 2))
     dsp.send (3)
     val captor = dsp.receive().capture()
@@ -104,7 +104,7 @@ class DispatcherSpec extends FlatSpec {
 
   it should "queue several receievers, and deliver messages immediately" in {
     implicit val scheduler = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
+    val dsp = new Dispatcher [Int]
     val c1 = dsp.receive().capture()
     val c2 = dsp.receive().capture()
     dsp.send (1)

--- a/disk/test/com/treode/disk/MultiplexerSpec.scala
+++ b/disk/test/com/treode/disk/MultiplexerSpec.scala
@@ -28,7 +28,7 @@ class MultiplexerSpec extends FlatSpec {
 
   "The Multiplexer" should "relay messages from the dispatcher" in {
     implicit val scheduler = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
+    val dsp = new Dispatcher [Int]
     val mplx = new Multiplexer (dsp)
     dsp.send (1)
     mplx.expect (1)
@@ -37,7 +37,7 @@ class MultiplexerSpec extends FlatSpec {
 
   it should "return open rejects to the dispatcher" in {
     implicit val scheduler = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
+    val dsp = new Dispatcher [Int]
     val mplx = new Multiplexer (dsp)
     dsp.send (1)
     dsp.send (2)
@@ -49,7 +49,7 @@ class MultiplexerSpec extends FlatSpec {
 
   it should "relay exclusive messages when available" in {
     implicit val scheduler = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
+    val dsp = new Dispatcher [Int]
     val mplx = new Multiplexer (dsp)
     mplx.send (2)
     mplx.expect (2)
@@ -58,7 +58,7 @@ class MultiplexerSpec extends FlatSpec {
 
   it should "recycle exclusive messages rejected by an earlier receptor" in {
     implicit val scheduler = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
+    val dsp = new Dispatcher [Int]
     val rcpt1 = dsp.receptor()
     val mplx = new Multiplexer (dsp)
     val rcpt2 = mplx.receptor()
@@ -72,7 +72,7 @@ class MultiplexerSpec extends FlatSpec {
 
   it should "recycle exclusive messages rejected by a later receptor" in {
     implicit val scheduler = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
+    val dsp = new Dispatcher [Int]
     val rcpt1 = dsp.receptor()
     val mplx = new Multiplexer (dsp)
     mplx.send (2)
@@ -84,7 +84,7 @@ class MultiplexerSpec extends FlatSpec {
 
   it should "close immediately when a receiver is waiting" in {
     implicit val scheduler = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
+    val dsp = new Dispatcher [Int]
     val mplx = new Multiplexer (dsp)
     val rcpt = mplx.receptor()
     mplx.close() .expectPass()
@@ -95,7 +95,7 @@ class MultiplexerSpec extends FlatSpec {
 
   it should "delay close when a until a receiver is waiting" in {
     implicit val scheduler = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
+    val dsp = new Dispatcher [Int]
     val mplx = new Multiplexer (dsp)
     val cb = mplx.close().capture()
     scheduler.run()
@@ -113,7 +113,7 @@ class MultiplexerSpec extends FlatSpec {
   it should "recycle rejects until accepted" in {
 
     implicit val scheduler = StubScheduler.random()
-    val dsp = new Dispatcher [Int] (0)
+    val dsp = new Dispatcher [Int]
 
     var received = Set.empty [Int]
 


### PR DESCRIPTION
The fiber wraps an ArrayDeque with synchronized to serialize tasks. The Dispatcher can more efficiently wrap ArrayDeque and UnrolledBuffer with synchronized to serialized tasks, rather than using a fiber for that.

A setter for batch allows the batch number to be raised after creation. This will help cleanup circular dependencies in creating components during log replay. Specifically, log replay needs a dispatcher, but the value of the batch number is not known until log replay completes.