### PR TITLE
Clean up API for PicklerRegistry.

### DIFF
--- a/async/src/com/treode/async/io/File.scala
+++ b/async/src/com/treode/async/io/File.scala
@@ -43,14 +43,17 @@ import Async.{async, guard, when}
   * The mated method `frame` lives in [[com.treode.pickle.Pickler Pickler]].
   *
   * @define Deframe
-  * Ensure `input` has at least four readable bytes, reading from the file if necessary.
-  * Interpret those as the length of bytes needed.  Read from the file again if necessary,
-  * until `input` has at least that many additional readable bytes.
+  * Ensure `input` has at least four readable bytes, reading from the file if necessary. Interpret
+  * those as the length of bytes needed. Read from the file again if necessary, until `input` has
+  * at least that many additional readable bytes. The length read is understood to be the length
+  * of the value only, not including the length of itself.
   *
   * @define DeframeChecksum
-  * Ensure `input` has at enough bytes for the checksum and integer length, reading from the file
+  * Ensure `input` has at enough bytes for the length and checksum, reading from the file
   * if necessary. Read from the file again if necessary, until `input` has enough readable bytes
-  * for the frame length. Finally, hash the frame bytes and check it against the checksum.
+  * for the checksum and frame length. Finally, hash the frame bytes and check it against the
+  * checksum.  The length read is understood to be the length of the value only, not including the
+  * length of itself or checksum.
   */
 class File private [io] (file: AsynchronousFileChannel) (implicit scheduler: Scheduler) {
 

--- a/cluster/src/com/treode/cluster/RemoteConnection.scala
+++ b/cluster/src/com/treode/cluster/RemoteConnection.scala
@@ -26,7 +26,7 @@ import com.treode.async.implicits._
 import com.treode.async.io.Socket
 import com.treode.async.misc.RichInt
 import com.treode.buffer.PagedBuffer
-import com.treode.pickle.Pickler
+import com.treode.pickle.{PickledValue, Pickler}
 
 private class RemoteConnection (
   val id: HostId,
@@ -43,8 +43,7 @@ private class RemoteConnection (
 
   require (id != localId)
 
-  type PickledMessage = PagedBuffer => Unit
-  type Queue = util.ArrayList [PickledMessage]
+  type Queue = util.ArrayList [PickledValue]
 
   abstract class State {
 
@@ -63,7 +62,7 @@ private class RemoteConnection (
       state = Closed
     }
 
-    def send (message: PickledMessage) = ()
+    def send (message: PickledValue) = ()
   }
 
   abstract class HaveSocket extends State {
@@ -73,8 +72,8 @@ private class RemoteConnection (
     def buffer: PagedBuffer
     def backoff: Iterator [Int]
 
-    def enque (message: PickledMessage) {
-      message (buffer)
+    def enque (message: PickledValue) {
+      PortRegistry.frame (message, buffer)
     }
 
     override def disconnect (socket: Socket) {
@@ -110,7 +109,7 @@ private class RemoteConnection (
       _close (socket)
     }
 
-    override def send (message: PickledMessage): Unit =
+    override def send (message: PickledValue): Unit =
       enque (message)
   }
 
@@ -118,7 +117,7 @@ private class RemoteConnection (
 
     val time = System.currentTimeMillis
 
-    override def send (message: PickledMessage) {
+    override def send (message: PickledValue) {
       if (address != null) {
         val socket = Socket.open (group)
         greet (socket)
@@ -153,7 +152,7 @@ private class RemoteConnection (
         state = Sending (socket, clientId)
       }}
 
-    override def send (message: PickledMessage) {
+    override def send (message: PickledValue) {
       enque (message)
       flush (socket, buffer)
       state = Sending (socket, clientId)
@@ -289,7 +288,7 @@ private class RemoteConnection (
   }
 
   def send [M] (p: Pickler [M], port: PortId, msg: M): Unit = fiber.execute {
-    state.send (PortRegistry.frame (p, port, msg, _))
+    state.send (PickledValue (port.id, p, msg))
   }
 
   override def hashCode() = id.hashCode()

--- a/cluster/src/com/treode/cluster/RequestDescriptor.scala
+++ b/cluster/src/com/treode/cluster/RequestDescriptor.scala
@@ -19,7 +19,7 @@ package com.treode.cluster
 import scala.util.{Failure, Success, Try}
 
 import com.treode.async.Async
-import com.treode.pickle.{Pickler, Picklers}
+import com.treode.pickle.Pickler
 
 import Async.guard
 
@@ -32,12 +32,12 @@ class RequestDescriptor [Q, A] private (
   type Port = EphemeralPort [Option [A]]
 
   private val _preq = {
-    import Picklers._
-    tuple (PortId.pickler, preq)
+    import ClusterPicklers._
+    tuple (portId, preq)
   }
 
   private val _prsp = {
-    import Picklers._
+    import ClusterPicklers._
     option (prsp)
   }
 

--- a/cluster/src/com/treode/cluster/Scuttlebutt.scala
+++ b/cluster/src/com/treode/cluster/Scuttlebutt.scala
@@ -36,11 +36,11 @@ private class Scuttlebutt (localId: HostId, peers: PeerRegistry) (implicit sched
     ports.loopback (desc.pmsg, desc.id.id, msg)
 
   def unpickle (id: RumorId, msg: Array [Byte]): Handler =
-    ports.unpickle (id.id, ArrayBuffer.readable (msg))
+    ports.unpickle (id.id, msg)
 
   def listen [M] (desc: RumorDescriptor [M]) (f: (M, Peer) => Any): Unit =
     fiber.execute {
-      ports.register (desc.pmsg, desc.id.id) (f.curried)
+      ports.register (desc.id.id, desc.pmsg) (f.curried)
       for {
         (host, state) <- universe
         (msg, _) <- state get (desc.id)

--- a/disk/src/com/treode/disk/LogIterator.scala
+++ b/disk/src/com/treode/disk/LogIterator.scala
@@ -145,6 +145,7 @@ private class LogIterator private (
         case Entry (batch, id) =>
           val end = logBuf.readPos
           val entry = records.read (id.id, logBuf, len - end + start)
+          logBuf.discard (logBuf.readPos)
           logPos += len + 4
           checkpointer.tally(len + 4, 1)
           f (Iterable ((batch, entry))) run (_next)

--- a/disk/src/com/treode/disk/RecordRegistry.scala
+++ b/disk/src/com/treode/disk/RecordRegistry.scala
@@ -16,7 +16,7 @@
 
 package com.treode.disk
 
-import com.treode.buffer.{ArrayBuffer, PagedBuffer}
+import com.treode.buffer.PagedBuffer
 import com.treode.pickle.PicklerRegistry
 
 private class RecordRegistry {
@@ -25,10 +25,10 @@ private class RecordRegistry {
     PicklerRegistry [Unit => Any] ("RecordRegistry")
 
   def replay [R] (desc: RecordDescriptor [R]) (f: R => Any): Unit =
-    records.register (desc.prec, desc.id.id) (msg => _ => f (msg))
+    records.register (desc.id.id, desc.prec) (msg => _ => f (msg))
 
   def read (id: TypeId, data: Array [Byte]): Unit => Any =
-    records.unpickle (id.id, ArrayBuffer.readable (data))
+    records.unpickle (id.id, data)
 
   def read (id: Long, buf: PagedBuffer, len: Int): Unit => Any =
     records.unpickle (id, buf, len)

--- a/pickle/src/com/treode/pickle/PickledValue.scala
+++ b/pickle/src/com/treode/pickle/PickledValue.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 Treode, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.treode.pickle
+
+import com.treode.buffer.OutputBuffer
+
+trait PickledValue {
+
+  def id: Long
+  def pickle (buf: OutputBuffer)
+}
+
+object PickledValue {
+
+  def apply [A] (_id: Long, p: Pickler [A], v: A): PickledValue =
+    new PickledValue {
+      def id = _id
+      def pickle (buf: OutputBuffer) = p.pickle (v, buf)
+    }}

--- a/pickle/src/com/treode/pickle/Pickler.scala
+++ b/pickle/src/com/treode/pickle/Pickler.scala
@@ -25,14 +25,16 @@ import com.treode.buffer.{ArrayBuffer, Buffer, Input, PagedBuffer, Output, Outpu
   *
   * @define Frame
   * Allow four bytes for the length, and write `v` after that. Once `v` has been written, compute
-  * its byte length and write that to the first four bytes. This begins writing the length at
-  * `writePos` and leaves `writePos` at the end of `v`.
+  * its byte length and write that to the first four bytes. The length is that of the value only;
+  * it does not include the length of itself. This starts writing the length at `writePos`, and it
+  * leaves `writePos` at the end of `v`.
   *
   * @define FrameChecksum
-  * Allow some number of bytes for the checksum, depedning on `hashf`, next allow four bytes for
-  * the length, and then write `v` after that. Once `v` has been written, compute its checksum and
-  * byte length and write that at the beginning. This begins writing the checksum and length at
-  * `writePos` and leaves `writePos` at the end of `v`.
+  * Allow four bytes for the length, next allow space for the checksum, finally write `v` after
+  * that. Once `v` has been written, compute its byte length and checksum, and write those at the
+  * beginning. The length is that of the value only; it does not include the length of itself or
+  * checksum. This starts writing the length and checksum at `writePos`, and it leaves `writePos`
+  * at the end of `v`.
   *
   * @define MatedDeframe
   * The mated `deframe` method lives in [[com.treode.async.io.File File]] and
@@ -106,7 +108,7 @@ trait Pickler [A] {
     buf.writePos = end
   }
 
-  /** Write a frame with its own checksum and length to the buffer.
+  /** Write a frame with its own length and checksum to the buffer.
     *
     * $FrameChecksum
     *

--- a/pickle/src/com/treode/pickle/PicklerRegistry.scala
+++ b/pickle/src/com/treode/pickle/PicklerRegistry.scala
@@ -19,20 +19,47 @@ package com.treode.pickle
 import java.util.concurrent.ConcurrentHashMap
 import scala.reflect.ClassTag
 
-import com.treode.buffer.{InputBuffer, PagedBuffer}
+import com.treode.buffer.{ArrayBuffer, InputBuffer, OutputBuffer, PagedBuffer}
 
 import PicklerRegistry._
 
+/** How to read objects of various types using a long to identify the type.
+  *
+  * When we know the type of a value that we want to deserialize, we can reach directly for the
+  * correct pickler. However when the value may be any type, we need a means to identify which
+  * pickler to use. The PicklerRegistry uses long (8 byte) tags to identify types.
+  *
+  * When we know the type of the value we are deserializing, we know its interface and can use the
+  * value immediately. However when the value may be any type, we need to hide it behind a common
+  * interface, so that we can treat the different types identically. Each of the types that can be
+  * deserialized must have a converter that performs this encapsulation. See the `register` method.
+  *
+  * Serialize values of various types by writing a long tag, then the value itself; see the
+  * `frame` methods in the companion object. Deseralize values by reading the long tag, then
+  * looking up the pickler to deserialize the value itself; see the `unpickle` methods.
+  *
+  * @tparam T The type that encapsulates deserialized values.
+  * @param default The function to compute
+  */
 class PicklerRegistry [T] private (default: Long => T) {
 
   private val openers = new ConcurrentHashMap [Long, Opener [T]]
 
-  def register [P] (p: Pickler [P], tag: Long) (read: P => T) {
-    val u1 = Opener (p, tag, read)
-    val u0 = openers.putIfAbsent (tag, u1)
-    require (u0 == null, f"$tag%X already registered")
+  /** Register a pickler to deserialize a tagged value.
+    * @param id The tag to identify the pickler.
+    * @param p The pickler to deserialize values identify by `id`.
+    * @param read The function to encapsulate the deserialized value.
+    */
+  def register [P] (id: Long, p: Pickler [P]) (read: P => T) {
+    val u1 = Opener (p, id, read)
+    val u0 = openers.putIfAbsent (id, u1)
+    require (u0 == null, f"$id%X already registered")
   }
 
+  /** Find an unsed tag, and register a pickler on it.
+    * @param p The pickler to deserialize values identified by the new tag.
+    * @return The new tag.
+    */
   def open [P] (p: Pickler [P]) (random: (Long, P => T)): Long = {
     var r = random
     var u1 = Opener (p, r._1, r._2)
@@ -45,46 +72,115 @@ class PicklerRegistry [T] private (default: Long => T) {
     r._1
   }
 
-  def unregister (tag: Long): Unit =
-    openers.remove (tag)
+  /** Unregister a pickler.
+    * @param id The tag to identify the pickler.
+    */
+  def unregister (id: Long): Unit =
+    openers.remove (id)
 
-  def unpickle (id: Long, buf: PagedBuffer, len: Int): T = {
-    val end = buf.readPos + len
-    val u = openers.get (id)
-    if (u == null) {
-      buf.readPos = end
-      buf.discard (buf.readPos)
-      return default (id)
-    }
-    val v = u.read (buf)
-    if (buf.readPos != end) {
-      buf.readPos = end
-      buf.discard (buf.readPos)
-      throw new FrameBoundsException
-    }
-    buf.discard (buf.readPos)
-    v
-  }
-
-  def unpickle (buf: PagedBuffer, len: Int): T =
-    unpickle (buf.readLong(), buf, len-8)
-
-  def unpickle (id: Long, buf: InputBuffer): T = {
+  private def _unpickle (id: Long, buf: InputBuffer): T = {
     val u = openers.get (id)
     if (u == null)
-      return default (id)
-    val v = u.read (buf)
-    if (buf.readableBytes > 0)
-      throw new FrameBoundsException
-    v
+      default (id)
+    else
+      u.read (buf)
   }
 
+  /** Lookup the pickler and deserialize the value.
+    * @param id The tag to identify the pickler.
+    * @param buf The buffer to deserialize from.
+    * @param len The length that the pickler should consume from the buffer.
+    * @throws FrameBoundsException If the pickler consumes the incorrect length from the buffer.
+    */
+  def unpickle (id: Long, buf: InputBuffer, len: Int): T =
+    try {
+      val end = buf.readPos + len
+      val u = openers.get (id)
+      if (u == null) {
+        buf.readPos = end
+        return default (id)
+      }
+      val v = u.read (buf)
+      if (buf.readPos != end)
+        throw new FrameBoundsException
+      v
+    } catch {
+      case t: Throwable =>
+        buf.readPos = len
+        throw t
+    }
+
+  /** Read the tag from the buffer, then lookup the pickler and deserialize the value.
+    * @param buf The buffer to deserialize from.
+    * @param len The length that the pickler should consume from the buffer.
+    * @throws FrameBoundsException If the pickler consumes the incorrect length from the buffer.
+    */
+  def unpickle (buf: InputBuffer, len: Int): T =
+    try {
+      val end = buf.readPos + len
+      val v = _unpickle (buf.readLong(), buf)
+      if (buf.readPos != end)
+        throw new FrameBoundsException
+      v
+    } catch {
+      case t: Throwable =>
+        buf.readPos = len
+        throw t
+    }
+
+  /** Read the tag from the buffer, then lookup the pickler and deserialize the value, then repeat.
+    * @param buf The buffer to deserialize from.
+    * @param len The length that the pickler should consume from the buffer.
+    * @param n The number of values to read.
+    * @throws FrameBoundsException If the picklers consume the incorrect length from the buffer.
+    */
+  def unpickle (buf: InputBuffer, len: Int, n: Int): Seq [T] =
+    try {
+      val end = buf.readPos + len
+      val vs = Seq.fill (n) (_unpickle (buf.readLong(), buf))
+      if (buf.readPos != end)
+        throw new FrameBoundsException
+      vs
+    } catch {
+      case t: Throwable =>
+        buf.readPos = len
+        throw t
+    }
+
+  /** Lookup the pickler and deserialize the value.
+    * @param id The tag to identify the pickler.
+    * @param bytes The bytes to deserialize from.
+    * @throws FrameBoundsException If the pickler does not consume exactly the given bytes.
+    */
+  def unpickle (id: Long, bytes: Array [Byte]): T =
+    unpickle (id, ArrayBuffer.readable (bytes), bytes.length)
+
+  /** Use the given pickler to serialize the value, and then lookup the pickler to deserialize the
+    * value.
+    *
+    * @param p The pickler to serialize the value.
+    * @param id The tag to identify the pickler for deserialization.
+    * @param v The value to convert.
+    * @throws FrameBoundsException If the deserializing pickler does not consume exactly the
+    * bytes produced by the serializing pickler.
+    */
   def loopback [P] (p: Pickler [P], id: Long, v: P): T = {
     val buf = PagedBuffer (12)
     p.pickle (v, buf)
     unpickle (id, buf, buf.writePos)
   }}
 
+/**
+  * @define Frame
+  * Allow four bytes for the length, and write `v` after that. Once `v` has been written, compute
+  * its byte length and write that to the first four bytes. The length is that of the value only;
+  * it does not include the length of itself. This starts writing the length at `writePos`, and it
+  * leaves `writePos` at the end of `v`.
+  *
+  * @define MatedDeframe
+  * The mated `deframe` method lives in [[com.treode.async.io.File File]] and
+  * [[com.treode.async.io.Socket Socket]].
+  */
 object PicklerRegistry {
 
   def apply [T] (default: Long => T): PicklerRegistry [T] =
@@ -93,8 +189,45 @@ object PicklerRegistry {
   def apply [T] (name: String): PicklerRegistry [T] =
     new PicklerRegistry (id => throw new InvalidTagException (name, id))
 
+  /** Write a frame with its own length to the buffer.
+    *
+    * $Frame
+    *
+    * $MatedDeframe
+    */
+  def frame (v: PickledValue, buf: OutputBuffer) {
+    val start = buf.writePos
+    buf.writePos += 4
+    buf.writeLong (v.id)
+    v.pickle (buf)
+    val end = buf.writePos
+    buf.writePos = start
+    buf.writeInt (end - start - 4)
+    buf.writePos = end
+  }
+
+  /** Write a frame with its own length to the buffer.
+    *
+    * $Frame
+    *
+    * $MatedDeframe
+    */
+  def frame (vs: Seq [PickledValue], buf: OutputBuffer) {
+    val start = buf.writePos
+    buf.writePos += 4
+    buf.writeInt (vs.size)
+    for (v <- vs) {
+      buf.writeLong (v.id)
+      v.pickle (buf)
+    }
+    val end = buf.writePos
+    buf.writePos = start
+    buf.writeInt (end - start - 4)
+    buf.writePos = end
+  }
+
   private trait Opener [T] {
-    def read (ctx: UnpickleContext): T
+
     def read (buf: InputBuffer): T
   }
 
@@ -102,9 +235,6 @@ object PicklerRegistry {
 
     def apply [ID, P, T] (p: Pickler [P], id: Long, reader: P => T): Opener [T] =
       new Opener [T] {
-
-        def read (ctx: UnpickleContext): T =
-          reader (p.u (ctx))
 
         def read (buf: InputBuffer): T =
           reader (p.unpickle (buf))

--- a/store/src/com/treode/store/catalog/Broker.scala
+++ b/store/src/com/treode/store/catalog/Broker.scala
@@ -51,12 +51,12 @@ private class Broker (
 
   private def deliver (id: CatalogId, cat: Handler): Unit =
     scheduler.execute {
-      ports.unpickle (id.id, ArrayBuffer.readable (cat.bytes.bytes))
+      ports.unpickle (id.id, cat.bytes.bytes)
     }
 
   def listen [C] (desc: CatalogDescriptor [C]) (f: C => Any): Unit =
     fiber.execute {
-      ports.register (desc.pcat, desc.id.id) (f)
+      ports.register (desc.id.id, desc.pcat) (f)
       catalogs get (desc.id) match {
         case Some (cat) if cat.bytes.murmur32 != 0 => deliver (desc.id, cat)
         case _ => ()


### PR DESCRIPTION
The API had some methods that checked the amount of data consumed, and others that did not. It had some methods that discarded consumed bytes from a PagedBuffer and others that did not. This was confusing. Now all methods check the amount of data consumed, and all methods let the caller decide how to discard consumed bytes.

This change closes [this bug](https://forum.treode.com/t/add-unpickle-method-to-picklerregistry-that-skips-checking-consumption/43), however it does so much differently than originally proposed.